### PR TITLE
fix(codex): repair MultiRouter routing and history sync

### DIFF
--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -51,12 +51,13 @@ const OFFICIAL_UNIFY_RESTORE_BACKUP_NAME: &str = "codex-official-history-unify-r
 /// SQLite 变量上限保守值，IN 列表按此分块。
 const STATE_DB_ID_CHUNK: usize = 500;
 
-/// 串行化官方历史的迁移与还原：开启迁移（启动重试 + 设置保存后台任务）和
-/// 关闭还原可能在毫秒级先后被触发，对同一批 jsonl / state DB 双向改写。
-static CODEX_OFFICIAL_HISTORY_OP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// 串行化所有历史 provider 桶写入：官方迁移/还原和 MultiRouter 同步可能由
+/// 启动、设置保存、provider 切换在毫秒级先后触发，必须避免对同一批 JSONL /
+/// state DB 并发或反向改写。
+static CODEX_HISTORY_PROVIDER_OP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-fn lock_codex_official_history_op() -> std::sync::MutexGuard<'static, ()> {
-    CODEX_OFFICIAL_HISTORY_OP_LOCK
+fn lock_codex_history_provider_op() -> std::sync::MutexGuard<'static, ()> {
+    CODEX_HISTORY_PROVIDER_OP_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
@@ -517,44 +518,66 @@ pub fn maybe_migrate_codex_openai_history_provider_bucket(
 /// MultiRouter 不能回到内置 `openai` provider，否则 Codex 会重新走官方
 /// OpenAI/WebSocket 语义；因此历史可见性通过手动同步到稳定路由桶解决。
 pub fn sync_codex_history_provider_bucket_to_multirouter(
-    db: &Database,
+    _db: &Database,
 ) -> Result<CodexHistoryProviderBucketMigrationOutcome, AppError> {
-    let mut source_provider_ids = collect_source_model_provider_ids(db)?;
-    source_provider_ids.insert(OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID.to_string());
-    for provider_id in CC_SWITCH_OPENAI_HISTORY_SOURCE_PROVIDER_IDS {
-        source_provider_ids.insert((*provider_id).to_string());
-    }
-    source_provider_ids.remove(CC_SWITCH_CODEX_ROUTER_MODEL_PROVIDER_ID);
+    ensure_codex_history_write_is_offline()?;
 
-    if source_provider_ids.is_empty() {
+    let live_config = read_codex_config_text().unwrap_or_default();
+    let target_provider = unified_history_target_provider(&live_config).ok_or_else(|| {
+        AppError::Message(
+            "当前 Codex live 配置没有可识别的 MultiRouter 稳定 provider 桶".to_string(),
+        )
+    })?;
+
+    sync_codex_history_provider_bucket_to_target(&target_provider)
+}
+
+fn sync_codex_history_provider_bucket_to_target(
+    target_provider: &str,
+) -> Result<CodexHistoryProviderBucketMigrationOutcome, AppError> {
+    let _op_guard = lock_codex_history_provider_op();
+    let backup_root = migration_backup_root(MULTIROUTER_CUSTOM_HISTORY_SYNC_NAME);
+    let codex_dir = get_codex_config_dir();
+    let (jsonl_source_provider_ids, migrated_jsonl_files) =
+        migrate_all_non_target_codex_jsonl_files(&codex_dir, &backup_root, target_provider)?;
+    let (state_source_provider_ids, migrated_state_rows) =
+        migrate_all_non_target_codex_state_dbs(&codex_dir, &backup_root, target_provider)?;
+    let mut source_provider_ids = jsonl_source_provider_ids;
+    source_provider_ids.extend(state_source_provider_ids);
+    let changed = migrated_jsonl_files > 0 || migrated_state_rows > 0;
+
+    Ok(CodexHistoryProviderBucketMigrationOutcome {
+        source_provider_ids: source_provider_ids.into_iter().collect(),
+        migrated_jsonl_files,
+        migrated_state_rows,
+        skipped_reason: (!changed).then(|| "already_target_or_no_history".to_string()),
+        backup_dir: changed.then(|| backup_root.to_string_lossy().to_string()),
+    })
+}
+
+/// 当统一历史开关与 MultiRouter 同时启用时，把当前历史归并到 live 使用的
+/// 稳定路由桶。普通官方统一历史仍由 custom 桶处理；两条路径不能互相写入
+/// 对方的桶，否则 Codex 会再次按 active provider 过滤掉全部旧会话。
+pub fn maybe_sync_codex_history_for_unified_multirouter(
+    _db: &Database,
+) -> Result<CodexHistoryProviderBucketMigrationOutcome, AppError> {
+    if !crate::settings::unify_codex_session_history() {
         return Ok(CodexHistoryProviderBucketMigrationOutcome {
-            skipped_reason: Some("no_source_provider_ids".to_string()),
+            skipped_reason: Some("unify_toggle_off".to_string()),
             ..Default::default()
         });
     }
 
-    let backup_root = migration_backup_root(MULTIROUTER_CUSTOM_HISTORY_SYNC_NAME);
-    let codex_dir = get_codex_config_dir();
-    let migrated_jsonl_files = migrate_codex_jsonl_files_to_target(
-        &codex_dir,
-        &source_provider_ids,
-        &backup_root,
-        CC_SWITCH_CODEX_ROUTER_MODEL_PROVIDER_ID,
-    )?;
-    let migrated_state_rows = migrate_codex_state_dbs_to_target(
-        &codex_dir,
-        &source_provider_ids,
-        &backup_root,
-        CC_SWITCH_CODEX_ROUTER_MODEL_PROVIDER_ID,
-    )?;
+    let live_config = read_codex_config_text().unwrap_or_default();
+    let Some(target_provider) = unified_history_target_provider(&live_config) else {
+        return Ok(CodexHistoryProviderBucketMigrationOutcome {
+            skipped_reason: Some("live_not_multirouter".to_string()),
+            ..Default::default()
+        });
+    };
 
-    Ok(CodexHistoryProviderBucketMigrationOutcome {
-        source_provider_ids: source_provider_ids.iter().cloned().collect(),
-        migrated_jsonl_files,
-        migrated_state_rows,
-        skipped_reason: None,
-        ..Default::default()
-    })
+    ensure_codex_history_write_is_offline()?;
+    sync_codex_history_provider_bucket_to_target(&target_provider)
 }
 
 /// 确认 Codex Desktop/app-server 已完全退出，避免 WAL 或目录同步覆盖离线修复。
@@ -3272,7 +3295,7 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
             ..Default::default()
         });
     }
-    let _op_guard = lock_codex_official_history_op();
+    let _op_guard = lock_codex_history_provider_op();
     let codex_dir = get_codex_config_dir();
     // marker 绑定迁移时的 Codex 目录：切换 codex_config_dir 后旧 marker 不再
     // 挡住新目录的迁移（迁移幂等，重跑无害）。
@@ -3339,15 +3362,47 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
 /// live config.toml 是否路由到共享 custom 桶（会话分桶只看这个实态：
 /// base_url / 接管与否都不影响 session_meta 记录的 model_provider）。
 fn codex_config_text_routes_custom(config_text: &str) -> bool {
+    codex_config_text_model_provider(config_text)
+        .is_some_and(|id| id == CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
+}
+
+fn codex_config_text_model_provider(config_text: &str) -> Option<String> {
     config_text
         .parse::<DocumentMut>()
         .ok()
         .and_then(|doc| {
             doc.get("model_provider")
                 .and_then(|item| item.as_str())
-                .map(|id| id.trim() == CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
+                .map(|id| id.trim().to_string())
         })
-        .unwrap_or(false)
+        .filter(|id| !id.is_empty())
+}
+
+/// 返回当前 live 配置中由 CCSwitchMulti 标记的稳定 MultiRouter provider。
+///
+/// 目标直接取 `model_provider` 的实际值，不假设某个构建版本的 bucket 名称。
+fn unified_history_target_provider(config_text: &str) -> Option<String> {
+    let doc = toml::from_str::<toml::Value>(config_text).ok()?;
+    let provider_id = doc
+        .get("model_provider")
+        .and_then(toml::Value::as_str)?
+        .trim();
+    if provider_id.is_empty() {
+        return None;
+    }
+
+    let provider = doc
+        .get("model_providers")
+        .and_then(toml::Value::as_table)
+        .and_then(|providers| providers.get(provider_id))
+        .and_then(toml::Value::as_table)?;
+    let router_marker = provider
+        .get("http_headers")
+        .and_then(toml::Value::as_table)
+        .and_then(|headers| headers.get("x-cc-switch-proxy-mode"))
+        .and_then(toml::Value::as_str);
+
+    (router_marker == Some("router")).then(|| provider_id.to_string())
 }
 
 /// 目录的规范化字符串形式，用作 marker / 备份代际的目录身份。
@@ -3417,7 +3472,7 @@ fn has_official_history_unify_backup_for_dir(ledger_parent: &Path, codex_dir_key
 /// 且只改写当前仍为 custom 的目标，重复执行无害。
 pub fn restore_codex_official_history_from_backups(
 ) -> Result<CodexOfficialHistoryRestoreOutcome, AppError> {
-    let _op_guard = lock_codex_official_history_op();
+    let _op_guard = lock_codex_history_provider_op();
     // 开关已（重新）开启时拒绝还原：live 正路由 custom，把账本会话翻回
     // openai 桶等于亲手制造分裂。覆盖"关闭保存成功后用户立刻重新开启，
     // 还原排在重开迁移之后才拿到 op lock"的时序。
@@ -4646,6 +4701,93 @@ mod tests {
     use serial_test::serial;
     use std::ffi::OsString;
     use tempfile::tempdir;
+
+    #[test]
+    fn unified_history_uses_the_active_multirouter_bucket() {
+        assert_eq!(
+            unified_history_target_provider(
+                r#"model_provider = "stable_router_v3"
+
+[model_providers.stable_router_v3]
+http_headers = { x-cc-switch-proxy-mode = "router" }
+"#,
+            )
+            .as_deref(),
+            Some("stable_router_v3")
+        );
+        assert_eq!(
+            unified_history_target_provider(
+                r#"model_provider = "custom"
+
+[model_providers.custom]
+base_url = "https://api.example.com/v1"
+"#,
+            ),
+            None,
+            "ordinary third-party providers must not trigger a global history rebucket"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn multirouter_history_sync_migrates_to_dynamic_target_and_is_idempotent() {
+        let dir = tempdir().expect("tempdir");
+        let _home_guard = EnvVarGuard::set("CC_SWITCH_TEST_HOME", dir.path());
+        let codex_dir = dir.path().join(".codex");
+        let sessions_dir = codex_dir.join("sessions");
+        fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+        let rollout = sessions_dir.join("dynamic-target.jsonl");
+        fs::write(
+            &rollout,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"one\",\"model_provider\":\"openai\"}}\n",
+        )
+        .expect("write rollout");
+
+        let db_path = codex_dir.join(CODEX_STATE_DB_FILENAME);
+        let conn = Connection::open(&db_path).expect("open state db");
+        create_history_test_threads_table(&conn);
+        conn.execute(
+            "INSERT INTO threads (id, rollout_path, model_provider) VALUES (?1, ?2, ?3)",
+            (
+                "one",
+                rollout.to_string_lossy().to_string(),
+                "legacy-router",
+            ),
+        )
+        .expect("insert thread");
+        drop(conn);
+
+        let first = sync_codex_history_provider_bucket_to_target("stable_router_v3")
+            .expect("sync dynamic target");
+
+        assert_eq!(first.migrated_jsonl_files, 1);
+        assert_eq!(first.migrated_state_rows, 1);
+        assert!(first.backup_dir.is_some());
+        assert!(fs::read_to_string(&rollout)
+            .expect("read migrated rollout")
+            .contains("\"model_provider\":\"stable_router_v3\""));
+        let conn = Connection::open(&db_path).expect("reopen state db");
+        let provider: String = conn
+            .query_row(
+                "SELECT model_provider FROM threads WHERE id = 'one'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read migrated provider");
+        assert_eq!(provider, "stable_router_v3");
+        drop(conn);
+
+        let second = sync_codex_history_provider_bucket_to_target("stable_router_v3")
+            .expect("rerun dynamic target sync");
+        assert_eq!(
+            (second.migrated_jsonl_files, second.migrated_state_rows),
+            (0, 0)
+        );
+        assert_eq!(
+            second.skipped_reason.as_deref(),
+            Some("already_target_or_no_history")
+        );
+    }
 
     struct EnvVarGuard {
         key: &'static str,

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -587,10 +587,10 @@ pub async fn unlock_codex_model_picker() -> Result<CodexModelPickerUnlockResult,
     crate::codex_desktop::unlock_codex_model_picker().await
 }
 
-/// 显式把 Codex 历史 provider 桶同步到 MultiRouter 的 `custom` 运行桶。
+/// 显式把 Codex 历史 provider 桶同步到当前 live 使用的稳定 MultiRouter 桶。
 ///
-/// 该命令会备份并重写本机 Codex session/jsonl 与 state sqlite；前端必须由用户主动触发，
-/// 不能在启动或诊断时自动执行。
+/// 该命令会备份并重写本机 Codex session/jsonl 与 state sqlite；自动入口也会复用同一条
+/// 离线检查与备份路径。
 #[tauri::command]
 pub async fn sync_codex_history_to_multirouter(
     state: tauri::State<'_, AppState>,

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -95,7 +95,8 @@ pub async fn save_settings(
             // 后台执行存量迁移（openai 桶 → custom 桶；仅当用户勾选了迁入既有
             // 会话，函数内部自门控）。大会话目录可能要读数秒，不能阻塞设置保存；
             // 失败时不写完成标记，下次启动自动重试。
-            tauri::async_runtime::spawn_blocking(|| {
+            let db_for_codex_history_sync = state.db.clone();
+            tauri::async_runtime::spawn_blocking(move || {
                 match crate::codex_history_migration::maybe_migrate_codex_official_history_to_unified_bucket() {
                     Ok(outcome) => {
                         if let Some(reason) = outcome.skipped_reason {
@@ -110,6 +111,25 @@ pub async fn save_settings(
                     }
                     Err(e) => {
                         log::warn!("✗ Codex official history unify migration failed: {e}");
+                    }
+                }
+
+                match crate::codex_history_migration::maybe_sync_codex_history_for_unified_multirouter(
+                    &db_for_codex_history_sync,
+                ) {
+                    Ok(outcome) => {
+                        if let Some(reason) = outcome.skipped_reason {
+                            log::debug!("○ Codex MultiRouter history sync skipped: {reason}");
+                        } else {
+                            log::info!(
+                                "✓ Codex MultiRouter history sync completed: jsonl_files={}, state_rows={}",
+                                outcome.migrated_jsonl_files,
+                                outcome.migrated_state_rows
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("✗ Codex MultiRouter history sync failed: {e}");
                     }
                 }
             });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -835,6 +835,27 @@ pub fn run() {
                             log::warn!("✗ Codex official history unify migration failed: {e}");
                         }
                     }
+
+                    match crate::codex_history_migration::maybe_sync_codex_history_for_unified_multirouter(
+                        &db_for_codex_history_migration,
+                    ) {
+                        Ok(outcome) => {
+                            if let Some(reason) = outcome.skipped_reason {
+                                log::debug!(
+                                    "○ Codex MultiRouter history sync skipped: {reason}"
+                                );
+                            } else {
+                                log::info!(
+                                    "✓ Codex MultiRouter history sync completed: jsonl_files={}, state_rows={}",
+                                    outcome.migrated_jsonl_files,
+                                    outcome.migrated_state_rows
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!("✗ Codex MultiRouter history sync failed: {e}");
+                        }
+                    }
                 });
             }
 

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1711,10 +1711,14 @@ impl RequestForwarder {
             .is_some();
         let codex_router_configured =
             matches!(app_type, AppType::Codex) && codex_provider_has_routing_config(provider);
+        // Retry chains may pre-resolve a route while preserving the parent router's
+        // base_url/auth. It still has to pass through target-provider materialization.
         let routed_provider = if matches!(app_type, AppType::Codex) {
-            (!provider_is_resolved_codex_route)
-                .then(|| super::providers::resolve_codex_model_routed_provider(provider, body))
-                .flatten()
+            if provider_is_resolved_codex_route {
+                Some(provider.clone())
+            } else {
+                super::providers::resolve_codex_model_routed_provider(provider, body)
+            }
         } else {
             None
         };
@@ -3407,12 +3411,15 @@ impl RequestForwarder {
             .is_some();
         let codex_router_configured =
             matches!(app_type, AppType::Codex) && codex_provider_has_routing_config(provider);
-        let routed_provider =
-            if matches!(app_type, AppType::Codex) && !provider_is_resolved_codex_route {
-                resolve_codex_raw_passthrough_route_provider(provider, route_body)
+        let routed_provider = if matches!(app_type, AppType::Codex) {
+            if provider_is_resolved_codex_route {
+                Some(provider.clone())
             } else {
-                None
-            };
+                resolve_codex_raw_passthrough_route_provider(provider, route_body)
+            }
+        } else {
+            None
+        };
         let routed_provider = if let Some(route_provider) = routed_provider {
             if let Some(target_provider_id) =
                 super::providers::codex_route_target_provider_id(&route_provider)
@@ -4078,12 +4085,15 @@ impl RequestForwarder {
             .is_some();
         let codex_router_configured =
             matches!(app_type, AppType::Codex) && codex_provider_has_routing_config(&provider);
-        let routed_provider =
-            if matches!(app_type, AppType::Codex) && !provider_is_resolved_codex_route {
-                resolve_codex_raw_passthrough_route_provider(&provider, route_body)
+        let routed_provider = if matches!(app_type, AppType::Codex) {
+            if provider_is_resolved_codex_route {
+                Some(provider.clone())
             } else {
-                None
-            };
+                resolve_codex_raw_passthrough_route_provider(&provider, route_body)
+            }
+        } else {
+            None
+        };
         let routed_provider = if let Some(route_provider) = routed_provider {
             if let Some(target_provider_id) =
                 super::providers::codex_route_target_provider_id(&route_provider)
@@ -6620,6 +6630,14 @@ mod tests {
     ) -> RequestForwarder {
         let db = Arc::new(Database::memory().expect("memory db"));
 
+        test_forwarder_with_db(db, non_streaming_timeout, streaming_first_byte_timeout)
+    }
+
+    fn test_forwarder_with_db(
+        db: Arc<Database>,
+        non_streaming_timeout: Duration,
+        streaming_first_byte_timeout: Duration,
+    ) -> RequestForwarder {
         RequestForwarder {
             router: Arc::new(ProviderRouter::new(db.clone())),
             status: Arc::new(RwLock::new(ProxyStatus::default())),
@@ -6640,6 +6658,122 @@ mod tests {
             streaming_first_byte_timeout,
             max_attempts: 1,
         }
+    }
+
+    #[tokio::test]
+    async fn resolved_codex_route_materializes_its_target_provider_for_all_http_paths() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind target provider mock");
+        let target_addr = listener.local_addr().expect("target provider mock addr");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                axum::Router::new().fallback(|| async {
+                    (
+                        StatusCode::OK,
+                        [(http::header::CONTENT_TYPE, "application/json")],
+                        r#"{"ok":true}"#,
+                    )
+                }),
+            )
+            .await
+            .expect("serve target provider mock");
+        });
+
+        let db = Arc::new(Database::memory().expect("memory db"));
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "target-provider".to_string(),
+                "Target Provider".to_string(),
+                json!({
+                    "base_url": format!("http://{target_addr}/v1"),
+                    "api_key": "sk-target"
+                }),
+                None,
+            ),
+        )
+        .expect("save target provider");
+        let mut resolved_route = test_provider_with_type(None);
+        resolved_route.id = "multirouter".to_string();
+        resolved_route.name = "MultiRouter".to_string();
+        resolved_route.settings_config = json!({
+            "base_url": "http://127.0.0.1:9/v1",
+            "api_key": "sk-parent",
+            "codexResolvedRouteId": "target-route",
+            "codexResolvedTargetProviderId": "target-provider"
+        });
+        db.save_provider("codex", &resolved_route)
+            .expect("save resolved route provider");
+        db.set_current_provider("codex", &resolved_route.id)
+            .expect("select resolved route provider");
+        let forwarder = test_forwarder_with_db(db, Duration::from_secs(1), Duration::from_secs(1));
+        let app_type = AppType::Codex;
+        let adapter = get_adapter(&app_type);
+        let method = http::Method::POST;
+        let headers = HeaderMap::new();
+        let extensions = Extensions::new();
+        let route_body = json!({"model": "deepseek-v4-flash", "stream": false});
+
+        let (response, _, effective_provider, _) = forwarder
+            .forward(
+                &app_type,
+                &method,
+                &resolved_route,
+                "/v1/responses",
+                &route_body,
+                &headers,
+                &extensions,
+                adapter.as_ref(),
+            )
+            .await
+            .expect("resolved route should use its target provider");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            effective_provider.settings_config["base_url"],
+            format!("http://{target_addr}/v1")
+        );
+        assert_eq!(effective_provider.settings_config["api_key"], "sk-target");
+
+        let (raw_response, raw_effective_provider, _) = forwarder
+            .forward_raw(
+                &app_type,
+                &method,
+                &resolved_route,
+                "/v1/custom",
+                &route_body,
+                Bytes::from_static(br#"{"model":"deepseek-v4-flash"}"#),
+                &headers,
+                &extensions,
+                adapter.as_ref(),
+            )
+            .await
+            .expect("resolved raw route should use its target provider");
+        assert_eq!(raw_response.status(), StatusCode::OK);
+        assert_eq!(
+            raw_effective_provider.settings_config["base_url"],
+            format!("http://{target_addr}/v1")
+        );
+        assert_eq!(
+            raw_effective_provider.settings_config["api_key"],
+            "sk-target"
+        );
+
+        let selected_raw_provider = forwarder
+            .resolve_codex_raw_endpoint_provider(&app_type, "/v1/custom", &route_body)
+            .await
+            .expect("selected resolved raw route should use its target provider");
+        assert_eq!(
+            selected_raw_provider.settings_config["base_url"],
+            format!("http://{target_addr}/v1")
+        );
+        assert_eq!(
+            selected_raw_provider.settings_config["api_key"],
+            "sk-target"
+        );
+
+        server.abort();
     }
 
     // 验证只有上游明确返回 Responses-Lite 不支持时，才触发剥头重试。

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -106,6 +106,35 @@ pub fn reapply_current_codex_official_live(state: &AppState) -> Result<bool, App
     Ok(true)
 }
 
+fn schedule_codex_unified_multirouter_history_sync(state: &AppState) {
+    if !crate::settings::unify_codex_session_history() {
+        return;
+    }
+
+    let db = state.db.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        match crate::codex_history_migration::maybe_sync_codex_history_for_unified_multirouter(&db)
+        {
+            Ok(outcome) => {
+                if let Some(reason) = outcome.skipped_reason {
+                    log::debug!("○ Codex MultiRouter history sync skipped: {reason}");
+                } else {
+                    log::info!(
+                        "✓ Codex MultiRouter history sync completed after provider switch: jsonl_files={}, state_rows={}",
+                        outcome.migrated_jsonl_files,
+                        outcome.migrated_state_rows
+                    );
+                }
+            }
+            Err(error) => {
+                log::warn!(
+                    "✗ Codex MultiRouter history sync after provider switch failed: {error}"
+                );
+            }
+        }
+    });
+}
+
 /// Provider business logic service
 pub struct ProviderService;
 
@@ -3743,6 +3772,7 @@ impl ProviderService {
             )
             .map_err(|e| AppError::Message(format!("启用 Codex 本地代理接管失败: {e}")))?;
 
+            schedule_codex_unified_multirouter_history_sync(state);
             return Ok(SwitchResult::default());
         }
 
@@ -3765,6 +3795,9 @@ impl ProviderService {
 
             // The proxy server will route requests to the new provider via is_current.
             // MCP sync is intentionally skipped while Live config is owned by takeover.
+            if matches!(app_type, AppType::Codex) {
+                schedule_codex_unified_multirouter_history_sync(state);
+            }
             return Ok(SwitchResult::default());
         }
 


### PR DESCRIPTION
## Summary

- Materialize pre-resolved Codex MultiRouter attempts from their referenced target provider before forwarding normal, raw, and realtime HTTP paths.
- Sync unified Codex history into the stable MultiRouter provider bucket currently declared by the live `config.toml`, instead of a hard-coded legacy bucket.
- Serialize official history migrations/restores and MultiRouter history syncs behind one provider-bucket operation lock.

## Root cause

The retry chain expands MultiRouter routes ahead of `forward()` and marks each attempt with `codexResolvedRouteId`. The forwarder treated that marker as if the target provider had already been materialized. As a result, the attempt retained the parent router's local `base_url` and authentication context, recursively called the local proxy, and skipped target-specific protocol/history handling.

Unified history sync also assumed a fixed MultiRouter bucket. Current builds generate a stable bucket in the live Codex config, so JSONL `session_meta.model_provider` values and SQLite `threads.model_provider` rows could be migrated into a bucket that Codex was not displaying.

## Changes

- Feed already-resolved route attempts through the existing target-provider lookup and materialization path.
- Cover standard Responses forwarding, raw passthrough, and raw/realtime provider resolution.
- Detect the active MultiRouter bucket from `model_provider` plus the `x-cc-switch-proxy-mode = "router"` marker.
- Rebucket all non-target JSONL and SQLite history into that live target, with offline-process checks, backups, transactions, idempotency, and shared locking.
- Trigger the guarded sync at startup, settings changes, and Codex provider switches.
- Add regression tests for route URL/auth materialization and dynamic history target migration.

## User impact

MultiRouter requests now reach the selected external or official upstream instead of recursively returning to `127.0.0.1`. Target-specific request conversion and chat-history enrichment can run against the effective provider. Unified Codex history remains visible after switching to MultiRouter.

## Validation

- Patched `v3.19.0-3` binary tested with `New Codex MultiRouter`.
  - OpenCode Go Responses route used `https://opencode.ai/zen/go/v1/responses` and returned HTTP 200.
  - OpenAI Official route used `https://chatgpt.com/backend-api/codex/responses` and returned HTTP 200.
  - MultiRouter history sync completed with 737 JSONL files and 1,009 SQLite rows.
- `cargo test codex_history_migration::tests --lib` — 52 passed.
- `cargo test proxy::forwarder::tests --lib` — 116 passed.
- Focused Codex Router, Codex Chat, provider refresh, and settings tests passed.
- `cargo check --lib` passed (one pre-existing unused-function warning remains in `proxy/usage/parser.rs`).
