### PR TITLE
fix(proxy): replay full Responses SSE lifecycle for hosted web_search buffered responses

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,0 +1,98 @@
+name: Build Installers
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows EXE
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build codex-history-repairer
+        run: cargo build --manifest-path src-tauri/Cargo.toml --bin codex-history-repairer --features history-repairer --release
+
+      - name: Build Tauri app (NSIS)
+        timeout-minutes: 60
+        run: pnpm tauri build --bundles nsis
+
+      - name: Upload EXE artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CCSwitchMulti-Windows-EXE
+          path: src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error
+
+  build-macos:
+    name: Build macOS DMG (universal)
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add macOS targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build codex-history-repairer (universal)
+        run: |
+          set -euxo pipefail
+          cargo build --manifest-path src-tauri/Cargo.toml --bin codex-history-repairer --features history-repairer --target aarch64-apple-darwin --release
+          cargo build --manifest-path src-tauri/Cargo.toml --bin codex-history-repairer --features history-repairer --target x86_64-apple-darwin --release
+          mkdir -p src-tauri/target/universal-apple-darwin/release
+          lipo -create \
+            src-tauri/target/aarch64-apple-darwin/release/codex-history-repairer \
+            src-tauri/target/x86_64-apple-darwin/release/codex-history-repairer \
+            -output src-tauri/target/universal-apple-darwin/release/codex-history-repairer
+
+      - name: Build Tauri app (universal)
+        timeout-minutes: 60
+        run: pnpm tauri build --target universal-apple-darwin
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CCSwitchMulti-macOS-DMG
+          path: |
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+          if-no-files-found: warn

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2500,6 +2500,13 @@ impl RequestForwarder {
                 obj.remove("stream_options");
             }
         }
+        // 出站 body 定稿后的真实上游流式状态。与 request_is_streaming（客户端
+        // Accept/body.stream 语义）分开记录，避免 hosted web_search 强制非流式时
+        // 路由日志里的 streaming=true 误导排障（issue #24）。
+        let upstream_stream = filtered_body
+            .get("stream")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
         // 出站 body 定稿后刷新真值（覆盖 Codex chat 上游模型覆写、转换层模型改写）
         if let Some(m) = filtered_body
             .get("model")
@@ -2549,6 +2556,7 @@ impl RequestForwarder {
                     codex_responses_to_anthropic.to_string(),
                 ),
                 ("streaming", request_is_streaming.to_string()),
+                ("upstream_stream", upstream_stream.to_string()),
                 (
                     "elapsed_ms",
                     request_prepare_started_at.elapsed().as_millis().to_string(),
@@ -3554,6 +3562,7 @@ impl RequestForwarder {
                         ("provider", provider.id.clone()),
                         ("status", status.as_u16().to_string()),
                         ("streaming", request_is_streaming.to_string()),
+                        ("upstream_stream", upstream_stream.to_string()),
                         (
                             "elapsed_ms",
                             response_prepare_started_at

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -3430,8 +3430,11 @@ async fn handle_codex_chat_to_responses_transform(
             "Cache-Control",
             axum::http::HeaderValue::from_static("no-cache"),
         );
-        let body =
-            axum::body::Body::from(responses_response_to_completed_sse(&responses_response)?);
+        // 客户端仍要求 SSE 时，合成完整的 Responses 事件生命周期
+        // （created → in_progress → output items → completed），而不是只发
+        // 一个 response.completed——Codex 需要 created 之前的增量事件才会把
+        // 这次响应记录为正常的 assistant turn。
+        let body = axum::body::Body::from(responses_response_to_full_sse(&responses_response)?);
         return Ok((headers, body).into_response());
     }
 
@@ -3725,6 +3728,129 @@ fn responses_response_to_completed_sse(response: &Value) -> Result<Bytes, ProxyE
     Ok(Bytes::from(format!(
         "event: response.completed\ndata: {payload}\n\n"
     )))
+}
+
+/// 把非流式 Responses JSON 展开成完整的 Responses SSE 事件生命周期。
+///
+/// 客户端声明 `stream: true` 但上游因 hosted 工具循环走缓冲路径时，只回一个
+/// `response.completed` 会让 Codex 无法把响应记为正常的 assistant turn（issue #24）。
+/// 这里按流式语义重放：`response.created` → `response.in_progress` → 每个 output
+/// item 的 `output_item.added` → 内容增量/done → `response.completed`，与
+/// `streaming_codex_chat` 转换器的输出形状保持一致。
+///
+/// 参数:
+/// - `response`: 已完成的 Responses JSON（`transform_codex_chat` 转换结果）。
+/// 返回:
+/// - 可直接返回给 Codex 流式客户端的完整 SSE 事件序列。
+/// 副作用:
+/// - 无。
+fn responses_response_to_full_sse(response: &Value) -> Result<Bytes, ProxyError> {
+    use super::providers::codex_responses_sse::{
+        function_call_arguments_done, message_close, message_content_part_added,
+        message_item_added, output_item_added, output_item_done, output_text_delta,
+        reasoning_close, reasoning_item_added, reasoning_summary_part_added,
+        reasoning_summary_text_delta, response_completed, response_created,
+        response_in_progress,
+    };
+
+    let mut events: Vec<Bytes> = Vec::new();
+    let base = json!({
+        "id": response.get("id").cloned().unwrap_or_else(|| json!("resp_ccswitch")),
+        "object": "response",
+        "created_at": response.get("created_at").cloned().unwrap_or_else(|| json!(0)),
+        "status": "in_progress",
+        "model": response.get("model").cloned().unwrap_or_else(|| json!("")),
+        "output": [],
+        "usage": response.get("usage").cloned().unwrap_or_else(|| json!({
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "output_tokens_details": { "reasoning_tokens": 0 }
+        }))
+    });
+    events.push(response_created(&base));
+    events.push(response_in_progress(&base));
+
+    let mut output_index: u32 = 0;
+    if let Some(items) = response.get("output").and_then(|v| v.as_array()) {
+        for item in items {
+            let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let item_id = item
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            match item_type {
+                "message" => {
+                    let text = item
+                        .pointer("/content/0/text")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    // 与 streaming_codex_chat 的增量路径保持一致：
+                    // added(in_progress) → content part → 一次性 delta → close。
+                    events.push(message_item_added(output_index, &item_id));
+                    events.push(message_content_part_added(output_index, &item_id));
+                    if !text.is_empty() {
+                        events.push(output_text_delta(output_index, &item_id, text));
+                    }
+                    events.extend(message_close(output_index, &item_id, text).0);
+                }
+                "reasoning" => {
+                    let text = item
+                        .pointer("/summary/0/text")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    events.push(reasoning_item_added(output_index, &item_id));
+                    events.push(reasoning_summary_part_added(output_index, &item_id));
+                    if !text.is_empty() {
+                        events.push(reasoning_summary_text_delta(
+                            output_index,
+                            &item_id,
+                            text,
+                        ));
+                    }
+                    events.extend(reasoning_close(output_index, &item_id, text).0);
+                }
+                "function_call" => {
+                    let name = item
+                        .pointer("/name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let arguments = item
+                        .get("arguments")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    events.push(output_item_added(output_index, item));
+                    if name.is_empty() {
+                        // 缺 name 直接 done，避免客户端卡在 in_progress。
+                        events.push(output_item_done(output_index, item));
+                    } else {
+                        events.push(function_call_arguments_done(
+                            output_index,
+                            &item_id,
+                            arguments,
+                        ));
+                        events.push(output_item_done(output_index, item));
+                    }
+                }
+                _ => {
+                    // custom_tool_call / tool_search_call 等：added + done 即完成。
+                    events.push(output_item_added(output_index, item));
+                    events.push(output_item_done(output_index, item));
+                }
+            }
+            output_index += 1;
+        }
+    }
+
+    events.push(response_completed(response));
+
+    Ok(Bytes::from(
+        events
+            .iter()
+            .map(|event| String::from_utf8_lossy(event).into_owned())
+            .collect::<String>(),
+    ))
 }
 
 /// Wrap a completed Responses value as an SSE stream containing exactly one
@@ -4998,7 +5124,8 @@ mod tests {
         resolve_codex_image_generation_provider, resolve_external_codex_router_target,
         resolve_forward_error_provider_for_logging, resolve_forward_error_route_provider,
         responses_response_to_compaction_sse, responses_response_to_completed_sse,
-        responses_sse_to_response_value, should_handle_as_codex_client,
+        responses_response_to_full_sse, responses_sse_to_response_value,
+        should_handle_as_codex_client,
         should_use_claude_transform_streaming, transform, upstream_body_parse_error,
     };
     use crate::{
@@ -5847,6 +5974,123 @@ data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\"}}\n
             payload["response"]["output"][0]["content"][0]["text"],
             "done"
         );
+    }
+
+    #[test]
+    fn full_sse_wrapper_emits_complete_responses_lifecycle() {
+        let response = json!({
+            "id": "resp_hosted_tool",
+            "object": "response",
+            "created_at": 1234,
+            "status": "completed",
+            "model": "kimi-k3",
+            "output": [
+                {
+                    "id": "rs_resp_hosted_tool",
+                    "type": "reasoning",
+                    "summary": [{ "type": "summary_text", "text": "thinking" }]
+                },
+                {
+                    "id": "resp_hosted_tool_msg",
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "done", "annotations": [] }]
+                },
+                {
+                    "id": "fc_call_0",
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_0",
+                    "name": "web_search",
+                    "arguments": r#"{"query":"test"}"#
+                }
+            ],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "output_tokens_details": { "reasoning_tokens": 3 }
+            }
+        });
+
+        let body = responses_response_to_full_sse(&response).unwrap();
+        let text = std::str::from_utf8(&body).expect("valid sse utf8");
+
+        // 生命周期顺序：created → in_progress → items → completed
+        assert!(text.starts_with("event: response.created\n"));
+        let created_idx = text.find("response.created").expect("created event");
+        let in_progress_idx = text.find("response.in_progress").expect("in_progress event");
+        let reasoning_added_idx =
+            text.find("response.output_item.added").expect("reasoning added");
+        let message_added_idx = text
+            .find("\"id\":\"resp_hosted_tool_msg\"")
+            .expect("message item");
+        let function_done_idx = text
+            .find("response.function_call_arguments.done")
+            .expect("function args done");
+        let completed_idx = text.find("response.completed").expect("completed event");
+        assert!(created_idx < in_progress_idx);
+        assert!(in_progress_idx < reasoning_added_idx);
+        assert!(reasoning_added_idx < message_added_idx);
+        assert!(message_added_idx < function_done_idx);
+        assert!(function_done_idx < completed_idx);
+
+        // 每个 item 都有 added 与 done 对（只统计 event: 行，data 里的 type 字段不计）
+        assert_eq!(
+            text.matches("event: response.output_item.added\n").count(),
+            3,
+            "one added per output item"
+        );
+        assert_eq!(
+            text.matches("event: response.output_item.done\n").count(),
+            3,
+            "one done per output item"
+        );
+        assert_eq!(
+            text.matches("event: response.reasoning_summary_text.done\n")
+                .count(),
+            1
+        );
+        assert_eq!(text.matches("event: response.output_text.done\n").count(), 1);
+        // 文本以一次性 delta 重放（与真实流式增量路径一致）
+        assert_eq!(text.matches("event: response.output_text.delta\n").count(), 1);
+        assert_eq!(
+            text.matches("event: response.reasoning_summary_text.delta\n")
+                .count(),
+            1
+        );
+
+        // completed 事件携带完整最终 response
+        let data_line = text
+            .lines()
+            .rev()
+            .find_map(|line| line.strip_prefix("data: "))
+            .expect("completed data line");
+        let payload: Value = serde_json::from_str(data_line).expect("sse payload json");
+        assert_eq!(payload["type"], "response.completed");
+        assert_eq!(payload["response"]["status"], "completed");
+        assert_eq!(payload["response"]["usage"]["output_tokens"], 5);
+    }
+
+    #[test]
+    fn full_sse_wrapper_handles_empty_output_and_fallback_ids() {
+        let response = json!({
+            "id": "resp_empty",
+            "status": "completed",
+            "model": "kimi-k3"
+        });
+
+        let body = responses_response_to_full_sse(&response).unwrap();
+        let text = std::str::from_utf8(&body).expect("valid sse utf8");
+
+        assert!(text.contains("event: response.created\n"));
+        assert!(text.contains("event: response.in_progress\n"));
+        // 无 output：只有 created/in_progress/completed 三个事件
+        assert_eq!(text.matches("event: response.").count(), 3);
+        // completed 事件是最后一块（事件块以空行结尾）
+        let completed_block = text.trim_end().rsplit("\n\n").next().unwrap_or("");
+        assert!(completed_block.starts_with("event: response.completed\n"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/wix/per-user-main.wxs
+++ b/src-tauri/wix/per-user-main.wxs
@@ -153,7 +153,7 @@
             </Component>
             <Component Id="Path" Guid="{{path_component_guid}}" Win64="$(var.Win64)">
                 <File Id="Path" Source="{{main_binary_path}}" KeyPath="no" Checksum="yes"/>
-                <RegistryValue Root="HKCU" Key="Software\{{manufacturer}}\{{product_name}}" Name="PathComponent" Type="integer" Value="1" KeyPath="yes" />
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="PathComponent" Type="integer" Value="1" KeyPath="yes" />
                 {{#each file_associations as |association| ~}}
                 {{#each association.ext as |ext| ~}}
                 <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="yes" Description="{{association.description}}">
@@ -167,7 +167,7 @@
             {{#each binaries as |bin| ~}}
             <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
                 <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="no"/>
-                <RegistryValue Root="HKCU" Key="Software\{{manufacturer}}\{{product_name}}" Name="Bin_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes" />
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Bin_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes" />
             </Component>
             {{/each~}}
             {{#if enable_elevated_update_task}}

--- a/src-tauri/wix/per-user-main.wxs
+++ b/src-tauri/wix/per-user-main.wxs
@@ -139,13 +139,13 @@
                 </RegistryKey>
                 <!-- Change the Root to HKCU for perUser installations -->
                 {{#each deep_link_protocols as |protocol| ~}}
-                <RegistryKey Root="HKCU" Key="Software\Classes\\{{protocol}}">
+                <RegistryKey Root="HKCU" Key="Software\\Classes\\{{protocol}}">
                     <RegistryValue Type="string" Name="URL Protocol" Value=""/>
                     <RegistryValue Type="string" Value="URL:{{bundle_id}} protocol"/>
                     <RegistryKey Key="DefaultIcon">
                         <RegistryValue Type="string" Value="&quot;[!Path]&quot;,0" />
                     </RegistryKey>
-                    <RegistryKey Key="shell\open\command">
+                    <RegistryKey Key="shell\\open\\command">
                         <RegistryValue Type="string" Value="&quot;[!Path]&quot; &quot;%1&quot;" />
                     </RegistryKey>
                 </RegistryKey>


### PR DESCRIPTION
## Summary

修复 #24：Kimi K3 via Codex MultiRouter 请求含 hosted `web_search` 时只返回一个 `response.completed` 事件，Codex 不记录为正常 assistant turn。

**根因**：hosted web_search 工具循环需要完整 Chat JSON，forwarder 因此强制上游 `stream:false`（forwarder.rs:2493），handler 检测到 hosted-tool-loop 标记后走缓冲路径，最终只序列化一个 `response.completed` SSE 事件。

**修复**：
1. `handlers.rs` 新增 `responses_response_to_full_sse`：把缓冲的 Responses JSON 合成完整事件生命周期（`response.created` → `response.in_progress` → 每个 output item 的 added/内容增量/done → `response.completed`），复用共享的 `codex_responses_sse` builders，wire shape 与真实流式转换器一致。message/reasoning item 用一次性 delta 重放，function_call 发 `function_call_arguments.done`，custom_tool_call/tool_search_call 走 added+done。
2. `forwarder.rs` trace 日志新增 `upstream_stream` 字段，与 `streaming`（客户端 Accept/body 语义）分开记录，避免 `streaming=true` 误导排障。

## 测试
- 新增 2 个单元测试：完整生命周期序列（事件顺序、added/done 配对、completed 携带最终 response）、空 output 兜底（3 个事件）。
- 本机无 Rust 工具链，未本地跑 `cargo test`；逻辑经 Python 镜像逐事件验证，等 CI 跑 `cargo fmt/clippy/test`。

## 验证计划
- [x] CI: cargo fmt --check / clippy -D warnings / cargo test