### PR TITLE
fix(proxy): 跨路由 Responses 历史修复（id 规整 / reasoning_text 400 / 256K 溢出 401 / 空 choices 422 / 空 system 400）

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,0 +1,104 @@
+name: Build Installers
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows EXE
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Disable updater artifacts
+        run: node -e "const f='src-tauri/tauri.conf.json';const c=JSON.parse(require('fs').readFileSync(f,'utf8'));c.bundle.createUpdaterArtifacts=false;require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n')"
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build codex-history-repairer
+        run: cargo build --manifest-path src-tauri/Cargo.toml --bin codex-history-repairer --features history-repairer --release
+
+      - name: Build Tauri app (NSIS)
+        timeout-minutes: 60
+        run: pnpm tauri build --bundles nsis
+
+      - name: Upload EXE artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CCSwitchMulti-Windows-EXE
+          path: src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error
+
+  build-macos:
+    name: Build macOS DMG (universal)
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add macOS targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Disable updater artifacts
+        run: node -e "const f='src-tauri/tauri.conf.json';const c=JSON.parse(require('fs').readFileSync(f,'utf8'));c.bundle.createUpdaterArtifacts=false;require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n')"
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build codex-history-repairer (universal)
+        run: |
+          set -euxo pipefail
+          cargo build --manifest-path src-tauri/Cargo.toml --bin codex-history-repairer --features history-repairer --target aarch64-apple-darwin --release
+          cargo build --manifest-path src-tauri/Cargo.toml --bin codex-history-repairer --features history-repairer --target x86_64-apple-darwin --release
+          mkdir -p src-tauri/target/universal-apple-darwin/release
+          lipo -create \
+            src-tauri/target/aarch64-apple-darwin/release/codex-history-repairer \
+            src-tauri/target/x86_64-apple-darwin/release/codex-history-repairer \
+            -output src-tauri/target/universal-apple-darwin/release/codex-history-repairer
+
+      - name: Build Tauri app (universal)
+        timeout-minutes: 60
+        run: pnpm tauri build --target universal-apple-darwin
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CCSwitchMulti-macOS-DMG
+          path: |
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,10 @@ jobs:
       - name: Install frontend deps
         run: pnpm install --frozen-lockfile
 
+      - name: Create updater-enabled Tauri config
+        shell: bash
+        run: printf '{"bundle":{"createUpdaterArtifacts":true}}' > "$RUNNER_TEMP/updater-config.json"
+
       - name: Prepare Tauri signing key
         shell: bash
         run: |
@@ -304,7 +308,7 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 "$max_attempts"); do
             echo "=== macOS build/notarization attempt ${attempt}/${max_attempts} ==="
-            if pnpm tauri build --target universal-apple-darwin; then
+            if pnpm tauri build --target universal-apple-darwin --config "${{ runner.temp }}/updater-config.json"; then
               echo "✅ macOS build/notarization succeeded"
               exit 0
             fi
@@ -345,9 +349,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           if ($env:WINDOWS_RELEASE_ARCH -eq 'arm64') {
-            pnpm tauri build --target aarch64-pc-windows-msvc --bundles nsis
+            pnpm tauri build --target aarch64-pc-windows-msvc --bundles nsis --config "${{ runner.temp }}/updater-config.json"
           } else {
-            pnpm tauri build --bundles nsis
+            pnpm tauri build --bundles nsis --config "${{ runner.temp }}/updater-config.json"
           }
 
       - name: Build Linux history repair sidecar
@@ -359,7 +363,7 @@ jobs:
 
       - name: Build Tauri App (Linux)
         if: runner.os == 'Linux'
-        run: pnpm tauri build --bundles appimage,deb,rpm
+        run: pnpm tauri build --bundles appimage,deb,rpm --config "${{ runner.temp }}/updater-config.json"
 
       - name: Prepare macOS Assets
         if: runner.os == 'macOS'

--- a/.github/workflows/supplemental-macos-release.yml
+++ b/.github/workflows/supplemental-macos-release.yml
@@ -115,7 +115,8 @@ jobs:
         timeout-minutes: 60
         run: |
           set -euxo pipefail
-          pnpm tauri build --target universal-apple-darwin
+          printf '{"bundle":{"createUpdaterArtifacts":true}}' > "$RUNNER_TEMP/updater-config.json"
+          pnpm tauri build --target universal-apple-darwin --config "$RUNNER_TEMP/updater-config.json"
 
       - name: Stage macOS release assets
         shell: bash

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -682,6 +682,57 @@ impl RequestForwarder {
         })
     }
 
+    /// 整流/裁剪重试成功后的统一记账：熔断与 half-open 结果、当前供应商、
+    /// 成功统计与 failover 切换。media 降级与 compaction 裁剪重试共用。
+    async fn record_rectifier_retry_success(
+        &self,
+        attempt_provider_id: &str,
+        persistent_provider_id: &str,
+        persistent_provider_name: &str,
+        app_type_str: &str,
+        used_half_open_permit: bool,
+    ) {
+        self.record_success_result(
+            attempt_provider_id,
+            persistent_provider_id,
+            app_type_str,
+            used_half_open_permit,
+        )
+        .await;
+
+        {
+            let mut current_providers = self.current_providers.write().await;
+            current_providers.insert(
+                app_type_str.to_string(),
+                (
+                    persistent_provider_id.to_string(),
+                    persistent_provider_name.to_string(),
+                ),
+            );
+        }
+
+        let mut status = self.status.write().await;
+        status.success_requests += 1;
+        status.last_error = None;
+        let should_switch = self.current_provider_id_at_start.as_str() != persistent_provider_id;
+        if should_switch {
+            status.failover_count += 1;
+            let fm = self.failover_manager.clone();
+            let ah = self.app_handle.clone();
+            let pid = persistent_provider_id.to_string();
+            let pname = persistent_provider_name.to_string();
+            let at = app_type_str.to_string();
+
+            tokio::spawn(async move {
+                let _ = fm.try_switch(ah.as_ref(), &at, &pid, &pname).await;
+            });
+        }
+        if status.total_requests > 0 {
+            status.success_rate =
+                (status.success_requests as f32 / status.total_requests as f32) * 100.0;
+        }
+    }
+
     /// 转发请求（带故障转移）
     ///
     /// 这是 thin wrapper：在客户端请求维度记一次 `total_requests` / 调整
@@ -1237,53 +1288,14 @@ impl RequestForwarder {
                                     outbound_model,
                                 )) => {
                                     log::info!("[{app_type_str}] [Media] Image retry succeeded");
-                                    self.record_success_result(
+                                    self.record_rectifier_retry_success(
                                         &attempt_provider_id,
                                         &persistent_provider_id,
+                                        &persistent_provider_name,
                                         app_type_str,
                                         used_half_open_permit,
                                     )
                                     .await;
-
-                                    {
-                                        let mut current_providers =
-                                            self.current_providers.write().await;
-                                        current_providers.insert(
-                                            app_type_str.to_string(),
-                                            (
-                                                persistent_provider_id.clone(),
-                                                persistent_provider_name.clone(),
-                                            ),
-                                        );
-                                    }
-
-                                    {
-                                        let mut status = self.status.write().await;
-                                        status.success_requests += 1;
-                                        status.last_error = None;
-                                        let should_switch =
-                                            self.current_provider_id_at_start.as_str()
-                                                != persistent_provider_id.as_str();
-                                        if should_switch {
-                                            status.failover_count += 1;
-                                            let fm = self.failover_manager.clone();
-                                            let ah = self.app_handle.clone();
-                                            let pid = persistent_provider_id.clone();
-                                            let pname = persistent_provider_name.clone();
-                                            let at = app_type_str.to_string();
-
-                                            tokio::spawn(async move {
-                                                let _ = fm
-                                                    .try_switch(ah.as_ref(), &at, &pid, &pname)
-                                                    .await;
-                                            });
-                                        }
-                                        if status.total_requests > 0 {
-                                            status.success_rate = (status.success_requests as f32
-                                                / status.total_requests as f32)
-                                                * 100.0;
-                                        }
-                                    }
 
                                     return Ok(ForwardResult {
                                         response,
@@ -1315,6 +1327,117 @@ impl RequestForwarder {
                                 }
                             }
                         }
+                    }
+
+                    // v2 compaction 上下文溢出重试：压缩请求携带整段回放历史，跨路由
+                    // 会话的历史按官方大窗口增长，切到 256K 级第三方模型（如 Kimi
+                    // k3-256k）时整请求被拒。压缩是摘要语义，确定性裁掉最旧历史
+                    // 是安全降级，优于让压缩流程整体卡死。两轮 1/2 → 1/4 阶梯裁剪。
+                    if codex_compaction_overflow_retry_requested(
+                        app_type,
+                        endpoint,
+                        &provider_body,
+                        &headers,
+                        &e,
+                    ) {
+                        let mut trim_failure = None;
+                        for round in 1..=2u8 {
+                            let (keep_num, keep_den) =
+                                if round == 1 { (1usize, 2usize) } else { (1, 4) };
+                            let mut trimmed_body = provider_body.clone();
+                            let stats = super::providers::openai_compat::trim_codex_compaction_input_for_context_retry(
+                                &mut trimmed_body,
+                                keep_num,
+                                keep_den,
+                            );
+                            if stats.removed_items == 0 {
+                                break;
+                            }
+                            let model = trimmed_body
+                                .get("model")
+                                .and_then(Value::as_str)
+                                .unwrap_or("");
+                            log::info!(
+                                "[{app_type_str}] [Compaction] Upstream rejected oversized v2 compaction; retrying provider={} model={} with {} oldest history item(s) trimmed ({} remain, round {round})",
+                                provider.id,
+                                model,
+                                stats.removed_items,
+                                stats.remaining_items,
+                            );
+
+                            match self
+                                .forward(
+                                    app_type,
+                                    &method,
+                                    provider,
+                                    endpoint,
+                                    &trimmed_body,
+                                    &headers,
+                                    &extensions,
+                                    adapter.as_ref(),
+                                )
+                                .await
+                            {
+                                Ok((
+                                    response,
+                                    claude_api_format,
+                                    routed_provider,
+                                    outbound_model,
+                                )) => {
+                                    log::info!(
+                                        "[{app_type_str}] [Compaction] Trimmed retry succeeded"
+                                    );
+                                    self.record_rectifier_retry_success(
+                                        &attempt_provider_id,
+                                        &persistent_provider_id,
+                                        &persistent_provider_name,
+                                        app_type_str,
+                                        used_half_open_permit,
+                                    )
+                                    .await;
+
+                                    return Ok(ForwardResult {
+                                        response,
+                                        provider: routed_provider,
+                                        claude_api_format,
+                                        outbound_model,
+                                        connection_guard: None,
+                                    });
+                                }
+                                Err(retry_err) => {
+                                    if round < 2 && is_codex_context_overflow_error(&retry_err) {
+                                        log::warn!(
+                                            "[{app_type_str}] [Compaction] Trimmed retry still overflows, trimming further: {retry_err}"
+                                        );
+                                        continue;
+                                    }
+                                    trim_failure = Some(retry_err);
+                                    break;
+                                }
+                            }
+                        }
+
+                        if let Some(retry_err) = trim_failure {
+                            log::warn!(
+                                "[{app_type_str}] [Compaction] Trimmed retry still failed: {retry_err}"
+                            );
+                            if let Some(err) = self
+                                .handle_rectifier_retry_failure(
+                                    retry_err,
+                                    provider,
+                                    app_type_str,
+                                    used_half_open_permit,
+                                    "compaction 裁剪",
+                                    &mut last_error,
+                                    &mut last_provider,
+                                )
+                                .await
+                            {
+                                return Err(err);
+                            }
+                            continue;
+                        }
+                        // 没有可裁剪的历史：落入常规错误处理。
                     }
 
                     if is_anthropic_provider {
@@ -5355,6 +5478,57 @@ pub(crate) fn codex_request_is_v2_compaction(
     !super::providers::is_codex_remote_compact_endpoint(endpoint)
         && summary.compaction_implementation.is_none()
         && summary.compaction_trigger.is_some()
+}
+
+/// 判断上游错误是否表示请求超出模型上下文窗口。
+///
+/// 各上游的溢出信号不统一：OpenAI 兼容端点通常是 400 + context_length_exceeded；
+/// Kimi For Coding 上下文溢出时返回 401 + "k3-256k supports only 256K context."
+/// （不是凭据错误，凭据错误不含 context 字样）。仅在 v2 compaction 裁剪重试
+/// 场景使用，误判代价只是多一次徒劳重试，不会改动正常请求。
+fn is_codex_context_overflow_error(error: &ProxyError) -> bool {
+    let ProxyError::UpstreamError { status, body } = error else {
+        return false;
+    };
+    if !matches!(*status, 400 | 401 | 413 | 422) {
+        return false;
+    }
+    let Some(body) = body else {
+        return false;
+    };
+    let body = body.to_ascii_lowercase();
+    const OVERFLOW_MARKERS: &[&str] = &[
+        "context_length_exceeded",
+        "maximum context length",
+        "context window",
+        "prompt is too long",
+        "input is too long",
+        "request_too_large",
+        "too many tokens",
+        "reduce the length",
+        "exceeds the context",
+    ];
+    if OVERFLOW_MARKERS.iter().any(|marker| body.contains(marker)) {
+        return true;
+    }
+    // Kimi For Coding：上下文溢出时返回 401 "k3-256k supports only 256K context."
+    body.contains("context") && body.contains("supports only")
+}
+
+/// 判断是否应对溢出失败的 v2 compaction 请求执行裁剪重试。
+///
+/// 只有 v2 compaction 会把整段历史放进单个请求；裁剪最旧历史对压缩语义是
+/// 安全降级（摘要不再覆盖被裁掉的早期历史），优于整请求失败。turn 请求和
+/// legacy /responses/compact 绝不进入裁剪路径。
+fn codex_compaction_overflow_retry_requested(
+    app_type: &AppType,
+    endpoint: &str,
+    body: &Value,
+    headers: &http::HeaderMap,
+    error: &ProxyError,
+) -> bool {
+    codex_request_is_v2_compaction(app_type, endpoint, body, headers)
+        && is_codex_context_overflow_error(error)
 }
 
 fn metadata_string_field(metadata: Option<&Value>, key: &str) -> Option<String> {
@@ -9484,6 +9658,99 @@ mod tests {
             "/v1/responses",
             &json!({"input":[{"type":"compaction_trigger"}]}),
             &legacy_v2_headers,
+        ));
+    }
+
+    #[test]
+    fn codex_context_overflow_error_matches_kimi_401_quirk() {
+        // Kimi For Coding 上下文溢出返回 401 + "supports only 256K context"，
+        // 不是凭据错误；必须被识别为可裁剪重试的溢出。
+        let err = ProxyError::UpstreamError {
+            status: 401,
+            body: Some("k3-256k supports only 256K context.".to_string()),
+        };
+        assert!(is_codex_context_overflow_error(&err));
+    }
+
+    #[test]
+    fn codex_context_overflow_error_rejects_real_auth_failure() {
+        // 同样是 401，凭据错误没有上下文溢出语义，不能触发裁剪重试。
+        let err = ProxyError::UpstreamError {
+            status: 401,
+            body: Some("invalid api key provided".to_string()),
+        };
+        assert!(!is_codex_context_overflow_error(&err));
+    }
+
+    #[test]
+    fn codex_context_overflow_error_matches_openai_and_anthropic_shapes() {
+        let openai = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(
+                "This model's maximum context length is 256000 tokens. context_length_exceeded"
+                    .to_string(),
+            ),
+        };
+        assert!(is_codex_context_overflow_error(&openai));
+
+        let anthropic = ProxyError::UpstreamError {
+            status: 400,
+            body: Some("prompt is too long: 300000 tokens > 200000 maximum".to_string()),
+        };
+        assert!(is_codex_context_overflow_error(&anthropic));
+    }
+
+    #[test]
+    fn codex_context_overflow_error_ignores_server_errors() {
+        let err = ProxyError::UpstreamError {
+            status: 500,
+            body: Some("internal error mentioning context window".to_string()),
+        };
+        assert!(!is_codex_context_overflow_error(&err));
+    }
+
+    #[test]
+    fn codex_compaction_overflow_retry_only_for_v2_compaction_overflow() {
+        let mut v2_headers = HeaderMap::new();
+        v2_headers.insert(
+            "x-codex-turn-metadata",
+            HeaderValue::from_static(
+                r#"{"request_kind":"compaction","compaction":{"trigger":"auto","implementation":"responses_compaction_v2","phase":"pre_turn"}}"#,
+            ),
+        );
+        let compaction_body = json!({"input":[{"type":"compaction_trigger"}]});
+        let overflow = ProxyError::UpstreamError {
+            status: 401,
+            body: Some("k3-256k supports only 256K context.".to_string()),
+        };
+        assert!(codex_compaction_overflow_retry_requested(
+            &AppType::Codex,
+            "/v1/responses",
+            &compaction_body,
+            &v2_headers,
+            &overflow,
+        ));
+
+        // turn 请求绝不裁剪：即使溢出也走常规故障转移。
+        assert!(!codex_compaction_overflow_retry_requested(
+            &AppType::Codex,
+            "/v1/responses",
+            &json!({"input":[{"type":"message","role":"user"}]}),
+            &HeaderMap::new(),
+            &overflow,
+        ));
+
+        // v2 compaction 遇到非溢出错误（如 502）不触发裁剪。
+        let server_error = ProxyError::UpstreamError {
+            status: 502,
+            body: Some("bad gateway".to_string()),
+        };
+        assert!(!codex_compaction_overflow_retry_requested(
+            &AppType::Codex,
+            "/v1/responses",
+            &compaction_body,
+            &v2_headers,
+            &server_error,
         ));
     }
 

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -6108,7 +6108,7 @@ fn should_normalize_codex_responses_passthrough_control_messages(
 fn is_chatgpt_codex_responses_upstream_url(url: &str) -> bool {
     #[cfg(test)]
     if let Ok(mock_url) = std::env::var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL") {
-        if url.trim_end_matches('/') == mock_url.trim_end_matches('/') {
+        if url.starts_with(mock_url.trim_end_matches('/')) {
             return true;
         }
     }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2661,7 +2661,12 @@ impl RequestForwarder {
 
             // Codex OAuth 特殊处理：从 CodexOAuthManager 获取真实 access_token
             if auth.strategy == AuthStrategy::CodexOAuth {
-                if let Some(app_handle) = &self.app_handle {
+                #[cfg(test)]
+                if std::env::var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL").is_ok() {
+                    auth = AuthInfo::new("mock-token".to_string(), AuthStrategy::CodexOAuth);
+                    is_codex_oauth = true;
+                    log::debug!("[CodexOAuth] test mock token injected");
+                } else if let Some(app_handle) = &self.app_handle {
                     let codex_state = app_handle.state::<CodexOAuthState>();
                     let codex_auth: tokio::sync::RwLockReadGuard<'_, CodexOAuthManager> =
                         codex_state.0.read().await;
@@ -6101,6 +6106,13 @@ fn should_normalize_codex_responses_passthrough_control_messages(
 ///   副作用:
 /// - 无。解析失败时保守返回 `false`，避免影响普通 OpenAI/兼容厂商。
 fn is_chatgpt_codex_responses_upstream_url(url: &str) -> bool {
+    #[cfg(test)]
+    if let Ok(mock_url) = std::env::var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL") {
+        if url.trim_end_matches('/') == mock_url.trim_end_matches('/') {
+            return true;
+        }
+    }
+
     let Ok(uri) = url.parse::<http::Uri>() else {
         return false;
     };

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -5531,6 +5531,18 @@ fn codex_compaction_overflow_retry_requested(
         && is_codex_context_overflow_error(error)
 }
 
+/// 判断 Chat Completions 响应是否缺少可转换的 choices。
+///
+/// 上游 HTTP 200 但 `choices` 缺失或为空是瞬态上游异常（Kimi 偶有发生），
+/// 不是客户端请求格式问题。调用方把它映射为 502 可重试错误，让 Codex 客户端
+/// 的 502 重连机制重试这一回合，而不是用 422 卡死整轮对话。
+pub(crate) fn chat_response_choices_empty(body: &Value) -> bool {
+    match body.get("choices").and_then(Value::as_array) {
+        Some(choices) => choices.is_empty(),
+        None => true,
+    }
+}
+
 fn metadata_string_field(metadata: Option<&Value>, key: &str) -> Option<String> {
     metadata?
         .get(key)
@@ -9752,6 +9764,16 @@ mod tests {
             &v2_headers,
             &server_error,
         ));
+    }
+
+    #[test]
+    fn chat_response_choices_empty_detects_missing_and_empty_choices() {
+        // Kimi 曾对正常请求返回 HTTP 200 + 空 choices；该形态必须被识别为
+        // 瞬态上游异常（映射 502 重试），否则转换层会以 422 卡死整轮对话。
+        assert!(chat_response_choices_empty(&json!({})));
+        assert!(chat_response_choices_empty(&json!({ "choices": [] })));
+        assert!(chat_response_choices_empty(&json!({ "choices": null })));
+        assert!(!chat_response_choices_empty(&json!({ "choices": [{}] })));
     }
 
     #[test]

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -3159,6 +3159,18 @@ async fn handle_codex_chat_to_responses_transform(
                 ));
             }
         };
+        // 上游 200 但 choices 为空是瞬态上游异常（Kimi 偶有发生），不是请求
+        // 格式问题。按 502 可重试错误返回，Codex 客户端的 502 重连机制会自动
+        // 重试这一回合；422 只会让整轮对话卡死。
+        if super::forwarder::chat_response_choices_empty(&chat_response) {
+            log::warn!("[Codex] 上游 Chat 返回 200 但 choices 为空，按 502 可重试异常处理");
+            return Err(ProxyError::UpstreamError {
+                status: 502,
+                body: Some(
+                    "upstream chat response returned HTTP 200 with empty choices".to_string(),
+                ),
+            });
+        }
         let responses_response = transform_codex_chat::chat_completion_to_response_with_context(
             chat_response,
             &tool_context,
@@ -3357,6 +3369,16 @@ async fn handle_codex_chat_to_responses_transform(
             ));
         }
     };
+    // 上游 200 但 choices 为空是瞬态上游异常（Kimi 偶有发生），不是请求
+    // 格式问题。按 502 可重试错误返回，Codex 客户端的 502 重连机制会自动
+    // 重试这一回合；422 只会让整轮对话卡死。
+    if super::forwarder::chat_response_choices_empty(&chat_response) {
+        log::warn!("[Codex] 上游 Chat 返回 200 但 choices 为空，按 502 可重试异常处理");
+        return Err(ProxyError::UpstreamError {
+            status: 502,
+            body: Some("upstream chat response returned HTTP 200 with empty choices".to_string()),
+        });
+    }
     let responses_response = transform_codex_chat::chat_completion_to_response_with_context(
         chat_response,
         &tool_context,

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -602,7 +602,13 @@ fn should_treat_target_as_managed_codex_oauth(
 /// 这些字段保留在持久 provider 里不会被改写；这里只清理 request-local effective
 /// provider，避免后续诊断或兼容逻辑再次把 `codex-official` 当成第三方中转。
 fn sanitize_materialized_managed_codex_oauth_settings(settings: &mut Map<String, JsonValue>) {
+    #[cfg(test)]
+    let keep_mock_base_url = std::env::var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL").is_ok();
     for key in ["base_url", "baseURL", "baseUrl", "apiKey", "api_key"] {
+        #[cfg(test)]
+        if keep_mock_base_url && key == "base_url" {
+            continue;
+        }
         settings.remove(key);
     }
 }
@@ -2449,6 +2455,17 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn extract_base_url(&self, provider: &Provider) -> Result<String, ProxyError> {
+        #[cfg(test)]
+        if std::env::var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL").is_ok() {
+            if let Some(url) = provider
+                .settings_config
+                .get("base_url")
+                .and_then(|v| v.as_str())
+            {
+                return Ok(url.trim_end_matches('/').to_string());
+            }
+        }
+
         // Codex v2 路由到 ChatGPT OAuth 时仍然固定使用 CodexAdapter；
         // 这里补齐托管账号 provider 的 base_url 语义，避免走普通 OpenAI 兼容配置解析。
         if provider_is_managed_codex_oauth(provider) || is_codex_official_provider(provider) {

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -527,6 +527,151 @@ fn codex_responses_reasoning_summary_to_content(summary: Option<&Value>) -> Opti
     ))
 }
 
+/// v2 compaction 上下文溢出重试的历史裁剪结果。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CodexCompactionTrimStats {
+    /// 被裁掉的历史 item 数。
+    pub removed_items: usize,
+    /// 裁剪后剩余的 input item 数。
+    pub remaining_items: usize,
+}
+
+/// 为上下文溢出重试裁剪 v2 compaction 请求的回放历史。
+///
+/// 裁剪规则（确定性）：
+/// - 结构性 item 永远保留：compaction 控制 item（compaction_trigger / compaction /
+///   compaction_summary / context_compaction）和最后一条 message（Codex 的压缩指令）；
+/// - 其余 item 按原始顺序只保留最新的 keep_num/keep_den，最旧的优先裁掉；
+/// - 裁剪后清理孤儿 tool output（其 call 已随前缀被裁掉的 output item），
+///   避免上游因 call_id 配对缺失再报 400。
+///
+/// 参数:
+/// - `body`: v2 compaction 的 Responses 请求体（原地修改）。
+/// - `keep_num` / `keep_den`: 可裁历史中保留最新的比例（如 1/2、1/4）。
+///   返回:
+/// - 裁剪统计；`removed_items == 0` 表示没有可裁内容，重试无意义。
+///   副作用:
+/// - 原地修改 `body` 的 `input` 数组。
+///   边界:
+/// - 只服务 v2 compaction 溢出重试；压缩是摘要语义，丢掉的早期历史只是不进
+///   摘要，优于整请求 400 导致压缩流程卡死。turn 请求绝不经过这里。
+pub(crate) fn trim_codex_compaction_input_for_context_retry(
+    body: &mut Value,
+    keep_num: usize,
+    keep_den: usize,
+) -> CodexCompactionTrimStats {
+    let Value::Object(object) = body else {
+        return CodexCompactionTrimStats::default();
+    };
+    let Some(Value::Array(items)) = object.get_mut("input") else {
+        return CodexCompactionTrimStats::default();
+    };
+
+    let keep_den = keep_den.max(1);
+    let last_message_index = items
+        .iter()
+        .rposition(|item| item.get("type").and_then(Value::as_str) == Some("message"));
+
+    let is_structural = |index: usize, item: &Value| {
+        if Some(index) == last_message_index {
+            return true;
+        }
+        matches!(
+            item.get("type").and_then(Value::as_str),
+            Some("compaction_trigger" | "compaction" | "compaction_summary" | "context_compaction")
+        )
+    };
+
+    let droppable_count = items
+        .iter()
+        .enumerate()
+        .filter(|(index, item)| !is_structural(*index, item))
+        .count();
+    let keep_count = droppable_count.saturating_mul(keep_num) / keep_den;
+    let mut to_remove = droppable_count.saturating_sub(keep_count);
+
+    let mut removed_items = 0usize;
+    let mut index = 0usize;
+    items.retain(|item| {
+        let remove = to_remove > 0 && !is_structural(index, item);
+        index += 1;
+        if remove {
+            to_remove -= 1;
+            removed_items += 1;
+        }
+        !remove
+    });
+
+    removed_items += drop_orphaned_compaction_tool_outputs(items);
+
+    CodexCompactionTrimStats {
+        removed_items,
+        remaining_items: items.len(),
+    }
+}
+
+/// 清理裁剪后孤儿 tool output：其 call 已不在 input 里的 output item。
+///
+/// 前缀裁剪只会把 call 留在被裁区间、output 留在保留区间（output 时序上在
+/// call 之后），单向产生孤儿 output；反方向的孤儿 call 不会由裁剪制造。
+/// 返回清理数量。
+fn drop_orphaned_compaction_tool_outputs(items: &mut Vec<Value>) -> usize {
+    const CALL_TYPES: &[&str] = &[
+        "function_call",
+        "custom_tool_call",
+        "mcp_tool_call",
+        "local_shell_call",
+        "computer_call",
+        "file_search_call",
+        "code_interpreter_call",
+        "web_search_call",
+        "image_generation_call",
+        "tool_search_call",
+    ];
+    const OUTPUT_TYPES: &[&str] = &[
+        "function_call_output",
+        "custom_tool_call_output",
+        "mcp_tool_call_output",
+        "computer_call_output",
+        "tool_search_output",
+    ];
+
+    // call item 的关联键既可能是 call_id 也可能是 id（取决于上游协议形态），
+    // 两个都收进保留集合，避免误删合法 output。
+    let surviving_call_keys: std::collections::HashSet<String> = items
+        .iter()
+        .filter(|item| {
+            matches!(
+                item.get("type").and_then(Value::as_str),
+                Some(item_type) if CALL_TYPES.contains(&item_type)
+            )
+        })
+        .flat_map(|item| [item.get("call_id"), item.get("id")].into_iter().flatten())
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect();
+
+    let mut removed = 0usize;
+    items.retain(|item| {
+        let Some(item_type) = item.get("type").and_then(Value::as_str) else {
+            return true;
+        };
+        if !OUTPUT_TYPES.contains(&item_type) {
+            return true;
+        }
+        // 无 call_id 的 output 形态不明，保守保留。
+        let Some(call_id) = item.get("call_id").and_then(Value::as_str) else {
+            return true;
+        };
+        if surviving_call_keys.contains(call_id) {
+            return true;
+        }
+        removed += 1;
+        false
+    });
+    removed
+}
+
 /// 提升 Codex Responses input 中的 system/developer 控制消息。
 ///
 /// 参数:
@@ -2711,6 +2856,108 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn compaction_trim_keeps_structural_items_and_newest_half() {
+        // 溢出重试第一轮（1/2）：compaction_trigger 和最后的压缩指令必须保留，
+        // 可裁历史只保留最新一半，call/output 配对不被破坏。
+        let mut body = json!({
+            "model": "k3-256k",
+            "input": [
+                { "type": "compaction_trigger" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "old question" }] },
+                { "type": "function_call", "call_id": "call_1", "name": "read", "arguments": "{}" },
+                { "type": "function_call_output", "call_id": "call_1", "output": "old result" },
+                { "type": "message", "role": "assistant", "content": [{ "type": "output_text", "text": "mid answer" }] },
+                { "type": "reasoning", "summary": [] },
+                { "type": "function_call", "call_id": "call_2", "name": "write", "arguments": "{}" },
+                { "type": "function_call_output", "call_id": "call_2", "output": "new result" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "compact now" }] }
+            ]
+        });
+
+        let stats = trim_codex_compaction_input_for_context_retry(&mut body, 1, 2);
+        let input = body["input"].as_array().expect("input array");
+
+        // 7 个可裁 item 保留最新 3 个（reasoning、call_2、output_2），裁掉最旧 4 个。
+        assert_eq!(stats.removed_items, 4);
+        assert_eq!(stats.remaining_items, 5);
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        assert_eq!(input[1]["type"], "reasoning");
+        assert_eq!(input[2]["call_id"], "call_2");
+        assert_eq!(input[3]["call_id"], "call_2");
+        assert_eq!(input[3]["output"], "new result");
+        assert_eq!(input[4]["content"][0]["text"], "compact now");
+    }
+
+    #[test]
+    fn compaction_trim_drops_orphan_tool_outputs_at_boundary() {
+        // 裁剪边界落在 call 与 output 之间时，孤儿 output 必须一并删除，
+        // 否则上游会因 call_id 配对缺失再报 400。
+        let mut body = json!({
+            "model": "k3-256k",
+            "input": [
+                { "type": "compaction_trigger" },
+                { "type": "function_call", "call_id": "call_1", "name": "read", "arguments": "{}" },
+                { "type": "reasoning", "summary": [] },
+                { "type": "function_call_output", "call_id": "call_1", "output": "orphaned" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "compact now" }] }
+            ]
+        });
+
+        let stats = trim_codex_compaction_input_for_context_retry(&mut body, 1, 2);
+        let input = body["input"].as_array().expect("input array");
+
+        // 可裁 3 个（call_1、reasoning、output_1）保留 1 个（output_1），
+        // call_1 被裁后 output_1 成孤儿，由孤儿清理删除。
+        assert_eq!(stats.removed_items, 3);
+        assert_eq!(stats.remaining_items, 2);
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        assert_eq!(input[1]["type"], "message");
+    }
+
+    #[test]
+    fn compaction_trim_quarter_round_keeps_only_recent_items() {
+        // 第二轮（1/4）：8 个可裁 item 只保留最新 2 个。
+        let mut items = vec![json!({ "type": "compaction_trigger" })];
+        for index in 0..8 {
+            items.push(json!({
+                "type": "message",
+                "role": if index % 2 == 0 { "user" } else { "assistant" },
+                "content": [{ "type": "input_text", "text": format!("turn {index}") }]
+            }));
+        }
+        let mut body = json!({ "model": "k3-256k", "input": items });
+
+        let stats = trim_codex_compaction_input_for_context_retry(&mut body, 1, 4);
+        let input = body["input"].as_array().expect("input array");
+
+        // 最后一条 message（turn 7，压缩指令）是结构 item；可裁为 turn 0..=6
+        // 共 7 个，保留最新 1 个（7*1/4=1），裁掉 6 个。
+        assert_eq!(stats.removed_items, 6);
+        assert_eq!(stats.remaining_items, 3);
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        assert_eq!(input[1]["content"][0]["text"], "turn 6");
+        assert_eq!(input[2]["content"][0]["text"], "turn 7");
+    }
+
+    #[test]
+    fn compaction_trim_without_droppable_history_returns_zero() {
+        // 只有控制 item 的压缩请求没有可裁内容，removed_items=0 让调用方
+        // 放弃重试，避免无效的上游调用。
+        let mut body = json!({
+            "model": "k3-256k",
+            "input": [
+                { "type": "compaction_trigger" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "compact now" }] }
+            ]
+        });
+
+        let stats = trim_codex_compaction_input_for_context_retry(&mut body, 1, 2);
+
+        assert_eq!(stats.removed_items, 0);
+        assert_eq!(stats.remaining_items, 2);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -246,8 +246,8 @@ pub(crate) fn normalize_codex_responses_passthrough_request_for_transport(
 /// 参数:
 /// - `request_body`: Codex Responses 请求体。
 ///   返回:
-/// - function_call arguments 已规整、历史 message id 已补 `msg_` 前缀、
-///   其余结构保持不变的请求体。
+/// - function_call arguments 已规整、消息类 item id 已按类型补
+///   `msg_`/`amsg_` 前缀，其余结构保持不变的请求体。
 ///   副作用:
 /// - 无。函数只转换传入 JSON 值。
 ///   边界:
@@ -260,7 +260,7 @@ fn normalize_codex_responses_passthrough_items(request_body: Value) -> Value {
     };
 
     normalize_codex_responses_function_call_arguments(&mut body);
-    normalize_codex_responses_message_item_ids(&mut body);
+    normalize_codex_responses_input_item_ids(&mut body);
 
     Value::Object(body)
 }
@@ -407,12 +407,13 @@ fn normalize_codex_responses_function_call_item_arguments(item: &mut Value) {
     object.insert("arguments".to_string(), Value::String(arguments));
 }
 
-/// 规整 Chat/Anthropic 上游消息 item 的历史 id。
+/// 规整 Responses input 消息类 item 的历史 id。
 ///
-/// Codex 会把第三方上游转换出的消息 id（如 `resp_chatcmpl-..._msg`）持久化，
-/// 下一轮切回官方 `/responses` 时会被拒绝：Responses 输入消息 id 必须以
-/// `msg_` 开头。这里幂等补齐前缀，避免旧会话跨 provider 切换后报 400。
-fn normalize_codex_responses_message_item_ids(body: &mut Map<String, Value>) {
+/// 官方 backend 对 id 前缀有按类型区分的校验：普通 message 必须 `msg_`，
+/// agent_message 必须 `amsg_`。Chat/Anthropic 转换出的旧历史可能带
+/// `resp_chatcmpl-..._msg`，此前修正又可能把原生 `amsg_...` 误加成
+/// `msg_amsg_...`；这里按类型幂等补齐，并恢复被双重前缀污染的 id。
+fn normalize_codex_responses_input_item_ids(body: &mut Map<String, Value>) {
     let Some(Value::Array(items)) = body.get_mut("input") else {
         return;
     };
@@ -421,19 +422,24 @@ fn normalize_codex_responses_message_item_ids(body: &mut Map<String, Value>) {
         let Value::Object(object) = item else {
             continue;
         };
-        if !matches!(
-            object.get("type").and_then(Value::as_str),
-            Some("message" | "agent_message")
-        ) {
-            continue;
-        }
+        let expected_prefix = match object.get("type").and_then(Value::as_str) {
+            Some("message") => "msg_",
+            Some("agent_message") => "amsg_",
+            _ => continue,
+        };
         let Some(Value::String(id)) = object.get_mut("id") else {
             continue;
         };
-        if id.is_empty() || id.starts_with("msg_") {
+        if id.is_empty() || id.starts_with(expected_prefix) {
             continue;
         }
-        *id = format!("msg_{id}");
+        if expected_prefix == "amsg_" {
+            if let Some(rest) = id.strip_prefix("msg_amsg_") {
+                *id = format!("amsg_{rest}");
+                continue;
+            }
+        }
+        *id = format!("{expected_prefix}{id}");
     }
 }
 
@@ -2457,8 +2463,52 @@ mod tests {
             "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg"
         );
         assert_eq!(input[1]["id"], "msg_ok");
-        assert_eq!(input[2]["id"], "msg_resp_msg_1_0");
+        assert_eq!(input[2]["id"], "amsg_resp_msg_1_0");
         assert_eq!(input[3]["id"], "fc_call_1");
+    }
+
+    #[test]
+    fn codex_responses_passthrough_preserves_native_agent_message_ids() {
+        // Codex 自身生成的 agent_message id 以 amsg_ 开头，官方 backend 也要求
+        // 这个前缀；不能像普通 message 一样统一改成 msg_。
+        let body = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "agent_message",
+                    "id": "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_responses_passthrough_request(body);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input[0]["id"], "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac");
+    }
+
+    #[test]
+    fn codex_oauth_responses_recovers_double_prefixed_agent_message_ids() {
+        // 旧版规整曾把 amsg_... 加成 msg_amsg_...；官方会拒绝并要求 amsg_ 前缀，
+        // 这里必须把双重前缀恢复回去，旧会话才能继续。
+        let body = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "agent_message",
+                    "id": "msg_amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_oauth_responses_request(body, false);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input[0]["id"], "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -246,7 +246,8 @@ pub(crate) fn normalize_codex_responses_passthrough_request_for_transport(
 /// 参数:
 /// - `request_body`: Codex Responses 请求体。
 ///   返回:
-/// - function_call arguments 已规整、其余结构保持不变的请求体。
+/// - function_call arguments 已规整、历史 message id 已补 `msg_` 前缀、
+///   其余结构保持不变的请求体。
 ///   副作用:
 /// - 无。函数只转换传入 JSON 值。
 ///   边界:

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -247,7 +247,8 @@ pub(crate) fn normalize_codex_responses_passthrough_request_for_transport(
 /// - `request_body`: Codex Responses 请求体。
 ///   返回:
 /// - function_call arguments 已规整、消息类 item id 已按类型补
-///   `msg_`/`amsg_` 前缀，其余结构保持不变的请求体。
+///   `msg_`/`amsg_` 前缀、reasoning item 已按第三方可回放性规整，
+///   其余结构保持不变的请求体。
 ///   副作用:
 /// - 无。函数只转换传入 JSON 值。
 ///   边界:
@@ -261,6 +262,7 @@ fn normalize_codex_responses_passthrough_items(request_body: Value) -> Value {
 
     normalize_codex_responses_function_call_arguments(&mut body);
     normalize_codex_responses_input_item_ids(&mut body);
+    normalize_codex_responses_passthrough_reasoning_items(&mut body);
 
     Value::Object(body)
 }
@@ -441,6 +443,88 @@ fn normalize_codex_responses_input_item_ids(body: &mut Map<String, Value>) {
         }
         *id = format!("{expected_prefix}{id}");
     }
+}
+
+/// 规整第三方 Responses 透传请求中的 reasoning item。
+///
+/// 官方路由回放的 reasoning item 只带 OpenAI 私有 `encrypted_content`，没有
+/// 可读文本；DeepSeek 等 thinking 模式上游要求历史 reasoning 必须携带
+/// `reasoning_text`，否则整请求 400（compaction v2 会回放完整历史，必然命中）。
+/// 这里按可回放性处理：已有文本 content 的原样保留；只有 summary 文本的提升为
+/// `reasoning_text` content 并移除私有密文；什么文本都没有的 item 直接丢弃。
+fn normalize_codex_responses_passthrough_reasoning_items(body: &mut Map<String, Value>) {
+    let Some(Value::Array(items)) = body.get_mut("input") else {
+        return;
+    };
+
+    items.retain_mut(|item| {
+        let Value::Object(object) = item else {
+            return true;
+        };
+        if object.get("type").and_then(Value::as_str) != Some("reasoning") {
+            return true;
+        }
+        if codex_responses_reasoning_item_has_text_content(object) {
+            return true;
+        }
+        object.remove("encrypted_content");
+        match codex_responses_reasoning_summary_to_content(object.get("summary")) {
+            Some(content) => {
+                object.insert("content".to_string(), content);
+                true
+            }
+            // 密文已随 encrypted_content 移除；无任何可读文本的 reasoning item
+            // 对第三方上游没有信息价值，只会触发 thinking 模式校验。
+            None => false,
+        }
+    });
+}
+
+/// 判断 reasoning item 的 content 是否已包含可回放的文本。
+///
+/// 参数:
+/// - `object`: `type=reasoning` 的 Responses input item。
+///   返回:
+/// - `true` 表示 content 里已有非空 reasoning 文本，第三方上游可直接接受。
+///   副作用:
+/// - 无。
+fn codex_responses_reasoning_item_has_text_content(object: &Map<String, Value>) -> bool {
+    let Some(content) = object.get("content") else {
+        return false;
+    };
+    let mut texts = Vec::new();
+    collect_codex_oauth_reasoning_content_text(content, &mut texts);
+    !texts.is_empty()
+}
+
+/// 把 reasoning summary 文本提升为第三方接受的 `reasoning_text` content。
+///
+/// 参数:
+/// - `summary`: reasoning item 的 `summary` 字段。
+///   返回:
+/// - 有可读文本时返回 `reasoning_text` 数组；否则返回 `None`。
+///   副作用:
+/// - 无。
+fn codex_responses_reasoning_summary_to_content(summary: Option<&Value>) -> Option<Value> {
+    let texts: Vec<String> = summary
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|part| part.get("text").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(str::to_string)
+        .collect();
+    if texts.is_empty() {
+        return None;
+    }
+
+    Some(Value::Array(
+        texts
+            .into_iter()
+            .map(|text| json!({ "type": "reasoning_text", "text": text }))
+            .collect(),
+    ))
 }
 
 /// 提升 Codex Responses input 中的 system/developer 控制消息。
@@ -2491,6 +2575,142 @@ mod tests {
         let input = normalized["input"].as_array().expect("input array");
 
         assert_eq!(input[0]["id"], "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac");
+    }
+
+    #[test]
+    fn codex_responses_passthrough_keeps_native_reasoning_text_content() {
+        // DeepSeek thinking 模式自身产生的 reasoning item 带 reasoning_text content，
+        // 回放时必须原样保留，否则上游 400。
+        let body = json!({
+            "model": "deepseek-v4-flash",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "93b00248-92fc-40a5-a15e-69fff8d66599",
+                    "summary": [],
+                    "content": [{ "type": "reasoning_text", "text": "inspect the route first" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_responses_passthrough_request(body);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["content"][0]["type"], "reasoning_text");
+        assert_eq!(input[0]["content"][0]["text"], "inspect the route first");
+    }
+
+    #[test]
+    fn codex_responses_passthrough_promotes_encrypted_reasoning_summary_to_content() {
+        // 官方路由回放的 reasoning item 只有 OpenAI 私有 encrypted_content 和 summary
+        // 文本；透传给第三方时把 summary 提升为 reasoning_text content 并移除密文，
+        // 让 DeepSeek thinking 模式有可回放的文本。
+        let body = json!({
+            "model": "deepseek-v4-flash",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_03daef03bee90739",
+                    "summary": [{ "type": "summary_text", "text": "Need to inspect the code." }],
+                    "encrypted_content": "gAAAAAB..."
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_responses_passthrough_request(body);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input.len(), 1);
+        assert!(input[0].get("encrypted_content").is_none());
+        assert_eq!(input[0]["content"][0]["type"], "reasoning_text");
+        assert_eq!(input[0]["content"][0]["text"], "Need to inspect the code.");
+    }
+
+    #[test]
+    fn codex_responses_passthrough_drops_unrecoverable_encrypted_reasoning() {
+        // 官方路由回放里 encrypted_content + 空 summary 的 reasoning item 没有任何
+        // 可读文本，第三方 thinking 模式上游会因此整请求 400；直接丢弃。
+        let body = json!({
+            "model": "deepseek-v4-flash",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_03daef03bee90739",
+                    "summary": [],
+                    "encrypted_content": "gAAAAAB..."
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "pong" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_responses_passthrough_request(body);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["type"], "message");
+    }
+
+    #[test]
+    fn codex_responses_passthrough_compaction_simulation_recovers_reasoning_history() {
+        // 仿真：跨路由会话的 compaction v2 请求混合三类 reasoning item
+        // （DeepSeek 原生、官方带 summary、官方空 summary），出站必须全部
+        // 满足 thinking 模式上游的 reasoning_text 校验。
+        let body = json!({
+            "model": "deepseek-v4-flash",
+            "input": [
+                { "type": "compaction_trigger" },
+                {
+                    "type": "reasoning",
+                    "summary": [],
+                    "content": [{ "type": "reasoning_text", "text": "native thinking" }]
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_official_1",
+                    "summary": [{ "type": "summary_text", "text": "official summary" }],
+                    "encrypted_content": "gAAAAAB..."
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_official_2",
+                    "summary": [],
+                    "encrypted_content": "gAAAAAB..."
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "compact now" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_responses_passthrough_request(body);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input.len(), 4);
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        assert_eq!(input[1]["content"][0]["text"], "native thinking");
+        assert!(input[2].get("encrypted_content").is_none());
+        assert_eq!(input[2]["content"][0]["type"], "reasoning_text");
+        assert_eq!(input[2]["content"][0]["text"], "official summary");
+        assert_eq!(input[3]["type"], "message");
+        for item in input {
+            if item["type"] == "reasoning" {
+                assert!(
+                    item["content"].as_array().is_some_and(|parts| parts
+                        .iter()
+                        .any(|part| part["text"]
+                            .as_str()
+                            .is_some_and(|text| !text.trim().is_empty()))),
+                    "third-party reasoning item must carry reasoning text: {item}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -2571,6 +2571,56 @@ mod tests {
     }
 
     #[test]
+    fn codex_oauth_compaction_simulation_drops_all_history_ids() {
+        // 仿真：把三类报错 id（resp_chatcmpl-..._msg、rs_resp_chatcmpl-...、
+        // msg_amsg_...）放进同一个 compaction v2 请求，完整走官方 OAuth 归一化，
+        // 出站 input 必须不带任何历史 item id，内容与工具结构保持不变。
+        let body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                { "type": "compaction_trigger" },
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "old turn" }]
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_resp_chatcmpl-L2v9jyTIwSBd0avrEPO8umbl",
+                    "summary": [{ "type": "summary_text", "text": "thinking" }]
+                },
+                {
+                    "type": "agent_message",
+                    "id": "msg_amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "done"
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_oauth_responses_request(body, false);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        for item in input {
+            assert!(
+                item.get("id").is_none(),
+                "official input must not carry replayed ids: {item}"
+            );
+        }
+        assert_eq!(input[1]["content"][0]["text"], "old turn");
+        assert_eq!(input[2]["summary"][0]["text"], "thinking");
+        assert_eq!(input[3]["content"][0]["text"], "subagent done");
+        assert_eq!(input[4]["call_id"], "call_1");
+    }
+
+    #[test]
     fn codex_oauth_responses_normalizes_message_ids_in_compaction_request() {
         // Codex pre-turn compaction v2 会把整段历史放进 /responses 请求再发往官方，
         // 历史里残留的 Chat 上游 message id 同样会触发 input[N].id 校验失败。

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -534,6 +534,10 @@ fn normalize_codex_oauth_input_item(item: Value) -> Value {
         object.remove("content");
     }
 
+    // Official backend forwards with store=false, so synthetic/replayed item ids
+    // are not persisted server-side and come back as 404. Send history inline.
+    object.remove("id");
+
     Value::Object(object)
 }
 
@@ -2490,9 +2494,9 @@ mod tests {
     }
 
     #[test]
-    fn codex_oauth_responses_recovers_double_prefixed_agent_message_ids() {
-        // 旧版规整曾把 amsg_... 加成 msg_amsg_...；官方会拒绝并要求 amsg_ 前缀，
-        // 这里必须把双重前缀恢复回去，旧会话才能继续。
+    fn codex_oauth_responses_strips_double_prefixed_agent_message_ids() {
+        // 旧版规整曾把 amsg_... 加成 msg_amsg_...；官方按 store=false 转发时
+        // 不会持久化这些 id，直接移除才能避免前缀校验和 404。
         let body = json!({
             "model": "gpt-5.4",
             "input": [
@@ -2508,12 +2512,13 @@ mod tests {
         let normalized = normalize_codex_oauth_responses_request(body, false);
         let input = normalized["input"].as_array().expect("input array");
 
-        assert_eq!(input[0]["id"], "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac");
+        assert!(input[0].get("id").is_none());
     }
 
     #[test]
-    fn codex_oauth_responses_normalizes_chat_sourced_message_ids() {
-        // 官方 OAuth 直透路径同样命中消息 id 校验，必须在 normalize 阶段修复。
+    fn codex_oauth_responses_strips_replayed_message_ids() {
+        // 官方 OAuth 直透路径使用 store=false，历史 message id 不会被服务端
+        // 持久化；直接移除 id，让历史按内联内容发送。
         let body = json!({
             "model": "gpt-5.4",
             "input": [
@@ -2534,11 +2539,35 @@ mod tests {
         let normalized = normalize_codex_oauth_responses_request(body, false);
         let input = normalized["input"].as_array().expect("input array");
 
-        assert_eq!(
-            input[0]["id"],
-            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg"
-        );
+        assert!(input[0].get("id").is_none());
         assert_eq!(input[1].get("id"), None);
+    }
+
+    #[test]
+    fn codex_oauth_responses_strips_unpersisted_reasoning_ids() {
+        // 官方 store=false 时，Chat 上游合成的 reasoning id（rs_resp_chatcmpl-...）
+        // 在官方服务端不存在，回放会 404；必须移除 id。
+        let body = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_resp_chatcmpl-L2v9jyTIwSBd0avrEPO8umbl",
+                    "summary": [{ "type": "summary_text", "text": "thinking" }]
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "pong" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_oauth_responses_request(body, false);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert!(input[0].get("id").is_none());
+        assert!(input[1].get("id").is_none());
     }
 
     #[test]
@@ -2572,10 +2601,7 @@ mod tests {
         let input = normalized["input"].as_array().expect("input array");
 
         assert_eq!(input[0]["type"], "compaction_trigger");
-        assert_eq!(
-            input[1]["id"],
-            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg"
-        );
+        assert!(input[1].get("id").is_none());
         assert_eq!(input[2]["type"], "function_call_output");
         assert!(input[3].get("id").is_none());
     }

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -259,6 +259,7 @@ fn normalize_codex_responses_passthrough_items(request_body: Value) -> Value {
     };
 
     normalize_codex_responses_function_call_arguments(&mut body);
+    normalize_codex_responses_message_item_ids(&mut body);
 
     Value::Object(body)
 }
@@ -403,6 +404,36 @@ fn normalize_codex_responses_function_call_item_arguments(item: &mut Value) {
 
     let arguments = canonicalize_tool_arguments(object.get("arguments"));
     object.insert("arguments".to_string(), Value::String(arguments));
+}
+
+/// 规整 Chat/Anthropic 上游消息 item 的历史 id。
+///
+/// Codex 会把第三方上游转换出的消息 id（如 `resp_chatcmpl-..._msg`）持久化，
+/// 下一轮切回官方 `/responses` 时会被拒绝：Responses 输入消息 id 必须以
+/// `msg_` 开头。这里幂等补齐前缀，避免旧会话跨 provider 切换后报 400。
+fn normalize_codex_responses_message_item_ids(body: &mut Map<String, Value>) {
+    let Some(Value::Array(items)) = body.get_mut("input") else {
+        return;
+    };
+
+    for item in items {
+        let Value::Object(object) = item else {
+            continue;
+        };
+        if !matches!(
+            object.get("type").and_then(Value::as_str),
+            Some("message" | "agent_message")
+        ) {
+            continue;
+        }
+        let Some(Value::String(id)) = object.get_mut("id") else {
+            continue;
+        };
+        if id.is_empty() || id.starts_with("msg_") {
+            continue;
+        }
+        *id = format!("msg_{id}");
+    }
 }
 
 /// 提升 Codex Responses input 中的 system/developer 控制消息。
@@ -2380,6 +2411,83 @@ mod tests {
         assert_eq!(input[0]["arguments"], "{}");
         assert_eq!(input[2]["arguments"], r#"{"raw_arguments":"{"}"#);
         assert_eq!(input[3]["role"], "user");
+    }
+
+    #[test]
+    fn codex_responses_passthrough_normalizes_chat_sourced_message_ids() {
+        // 第三方 Chat 上游转换出的消息 item id（resp_chatcmpl-..._msg）被 Codex
+        // 持久化后，切回官方 /responses 时必须规整成 msg_ 前缀，否则 400。
+        let body = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "pong" }]
+                },
+                {
+                    "type": "message",
+                    "id": "msg_ok",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "continue" }]
+                },
+                {
+                    "type": "agent_message",
+                    "id": "resp_msg_1_0",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_call_1",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{}"
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_responses_passthrough_request(body);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(
+            input[0]["id"],
+            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg"
+        );
+        assert_eq!(input[1]["id"], "msg_ok");
+        assert_eq!(input[2]["id"], "msg_resp_msg_1_0");
+        assert_eq!(input[3]["id"], "fc_call_1");
+    }
+
+    #[test]
+    fn codex_oauth_responses_normalizes_chat_sourced_message_ids() {
+        // 官方 OAuth 直透路径同样命中消息 id 校验，必须在 normalize 阶段修复。
+        let body = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "pong" }]
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "continue" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_oauth_responses_request(body, false);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(
+            input[0]["id"],
+            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg"
+        );
+        assert_eq!(input[1].get("id"), None);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/openai_compat.rs
+++ b/src-tauri/src/proxy/providers/openai_compat.rs
@@ -2491,6 +2491,45 @@ mod tests {
     }
 
     #[test]
+    fn codex_oauth_responses_normalizes_message_ids_in_compaction_request() {
+        // Codex pre-turn compaction v2 会把整段历史放进 /responses 请求再发往官方，
+        // 历史里残留的 Chat 上游 message id 同样会触发 input[N].id 校验失败。
+        let body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                { "type": "compaction_trigger" },
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "old turn" }]
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "done"
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "compact now" }]
+                }
+            ]
+        });
+
+        let normalized = normalize_codex_oauth_responses_request(body, false);
+        let input = normalized["input"].as_array().expect("input array");
+
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        assert_eq!(
+            input[1]["id"],
+            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg"
+        );
+        assert_eq!(input[2]["type"], "function_call_output");
+        assert!(input[3].get("id").is_none());
+    }
+
+    #[test]
     fn codex_oauth_responses_normalizer_promotes_control_messages_and_strips_tool_content() {
         // official OAuth passthrough 复用通用控制消息提升，同时仍执行 ChatGPT backend
         // 专属的 tool output content 清理。

--- a/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
@@ -176,7 +176,7 @@ impl AnthropicToResponsesState {
         match block_type {
             "text" => {
                 let output_index = self.next_output_index();
-                let item_id = format!("{}_msg_{output_index}", self.response_id);
+                let item_id = format!("msg_{}_{output_index}", self.response_id);
                 events.push(sse::message_item_added(output_index, &item_id));
                 events.push(sse::message_content_part_added(output_index, &item_id));
                 self.blocks.insert(

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -308,7 +308,7 @@ impl ChatToResponsesState {
 
         if !self.text.added {
             let output_index = self.next_output_index();
-            let item_id = format!("{}_msg", self.response_id);
+            let item_id = format!("msg_{}", self.response_id);
             self.text.output_index = Some(output_index);
             self.text.item_id = item_id.clone();
             self.text.added = true;
@@ -887,6 +887,24 @@ mod tests {
         assert!(output.contains("\"text\":\"Hello\""));
         assert!(output.contains("event: response.completed"));
         assert!(output.contains("\"input_tokens\":4"));
+    }
+
+    #[tokio::test]
+    async fn text_message_item_id_uses_msg_prefix() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_k3\",\"created\":123,\"model\":\"k3\",\"choices\":[{\"delta\":{\"content\":\"pong\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let events = parse_sse_events(&output);
+        let added = events
+            .iter()
+            .find(|event| event["type"] == "response.output_item.added")
+            .expect("output item added");
+
+        assert_eq!(added["item"]["type"], "message");
+        assert!(added["item"]["id"].as_str().unwrap().starts_with("msg_"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1296,7 +1296,7 @@ pub(crate) fn anthropic_response_to_responses_with_context(
         if !text_parts.is_empty() {
             let idx = output.len();
             output.push(json!({
-                "id": format!("{response_id}_msg_{idx}"),
+                "id": format!("msg_{response_id}_{idx}"),
                 "type": "message",
                 "status": "completed",
                 "role": "assistant",
@@ -2418,6 +2418,7 @@ mod tests {
         assert_eq!(result["id"], "resp_msg_1");
         assert_eq!(result["status"], "completed");
         assert_eq!(result["output"][0]["type"], "message");
+        assert!(result["output"][0]["id"].as_str().unwrap().starts_with("msg_"));
         assert_eq!(result["output"][0]["content"][0]["type"], "output_text");
         assert_eq!(result["output"][0]["content"][0]["text"], "Hello!");
         assert_eq!(result["usage"]["input_tokens"], 10);

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -2418,7 +2418,10 @@ mod tests {
         assert_eq!(result["id"], "resp_msg_1");
         assert_eq!(result["status"], "completed");
         assert_eq!(result["output"][0]["type"], "message");
-        assert!(result["output"][0]["id"].as_str().unwrap().starts_with("msg_"));
+        assert!(result["output"][0]["id"]
+            .as_str()
+            .unwrap()
+            .starts_with("msg_"));
         assert_eq!(result["output"][0]["content"][0]["type"], "output_text");
         assert_eq!(result["output"][0]["content"][0]["text"], "Hello!");
         assert_eq!(result["usage"]["input_tokens"], 10);

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -2009,7 +2009,7 @@ fn chat_message_to_response_output_item(message: &Value, response_id: &str) -> O
     }
 
     Some(json!({
-        "id": format!("{response_id}_msg"),
+        "id": format!("msg_{response_id}"),
         "type": "message",
         "status": "completed",
         "role": "assistant",
@@ -2019,7 +2019,7 @@ fn chat_message_to_response_output_item(message: &Value, response_id: &str) -> O
 
 fn empty_assistant_message_output_item(response_id: &str) -> Value {
     json!({
-        "id": format!("{response_id}_msg"),
+        "id": format!("msg_{response_id}"),
         "type": "message",
         "status": "incomplete",
         "role": "assistant",
@@ -3942,6 +3942,34 @@ mod tests {
             "bounded compact summary"
         );
         assert_eq!(result["model"], "route-model-after-switch");
+    }
+
+    #[test]
+    fn chat_completion_message_item_uses_msg_prefixed_id() {
+        // Codex 会持久化输出 message 的 id 并在下一轮回放；第三方 Chat 上游
+        // 转换出的 id 必须带 msg_ 前缀，否则切回官方 /responses 会被拒绝。
+        let chat = json!({
+            "id": "chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9",
+            "model": "k3",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        });
+
+        let result = chat_completion_to_response(chat).unwrap();
+        let output = result["output"].as_array().unwrap();
+        let message = output
+            .iter()
+            .find(|item| item["type"] == "message")
+            .expect("message output item");
+
+        assert_eq!(
+            message["id"],
+            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -844,19 +844,21 @@ fn map_reasoning_effort(effort: &str, mode: Option<&str>) -> Option<&'static str
 /// 否则返回 `invalid params, chat content has invalid message role: system (2013)`。
 /// 把所有 system 消息合并到首位，避免中间 system（如 Codex 的 `developer` 指令）触发该约束；
 /// 该重排对 OpenAI / DeepSeek 等宽松兼容层也是无损的。
+/// content 为 null / 空串 / 空白 / 空 part 数组的 system 消息对上游没有信息价值，
+/// Kimi 等严格端点会以 "message at position N with role 'system' must not be
+/// empty" 400 整请求，这里一并丢弃；数组形态的非空 system 统一提取文本后合并，
+/// 字符串是所有第三方 Chat 端点都接受的最大公约形态。
 fn collapse_system_messages_to_head(messages: Vec<Value>) -> Vec<Value> {
     let mut system_chunks: Vec<String> = Vec::new();
     let mut rest: Vec<Value> = Vec::with_capacity(messages.len());
 
     for msg in messages {
         if msg.get("role").and_then(|v| v.as_str()) == Some("system") {
-            if let Some(text) = msg.get("content").and_then(|v| v.as_str()) {
-                let trimmed = text.trim();
-                if !trimmed.is_empty() {
-                    system_chunks.push(text.to_string());
-                }
-                continue;
+            let text = chat_system_message_text(&msg);
+            if !text.trim().is_empty() {
+                system_chunks.push(text);
             }
+            continue;
         }
         rest.push(msg);
     }
@@ -870,6 +872,25 @@ fn collapse_system_messages_to_head(messages: Vec<Value>) -> Vec<Value> {
     }
     out.extend(rest);
     out
+}
+
+/// 提取 chat system 消息的可读文本，兼容字符串与 content part 数组形态；
+/// null / 缺失 / 空白片段统一归为空串。
+fn chat_system_message_text(message: &Value) -> String {
+    match message.get("content") {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(parts)) => parts
+            .iter()
+            .filter_map(|part| {
+                part.get("text")
+                    .and_then(Value::as_str)
+                    .or_else(|| part.as_str())
+            })
+            .filter(|text| !text.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n"),
+        _ => String::new(),
+    }
 }
 
 fn instruction_text(value: &Value) -> String {
@@ -3791,6 +3812,78 @@ mod tests {
         assert_eq!(out[1]["content"], "U1");
         assert_eq!(out[2]["content"], "A1");
         assert_eq!(out[3]["content"], "U2");
+    }
+
+    #[test]
+    fn collapse_system_messages_drops_effectively_empty_system() {
+        // Kimi 严格端点会拒绝空 system 消息（400 "system must not be empty"）；
+        // null / 空串 / 空白 / 空 part 数组形态都必须被丢弃，而非透传。
+        let input = vec![
+            json!({"role": "system", "content": null}),
+            json!({"role": "system", "content": ""}),
+            json!({"role": "system", "content": "   "}),
+            json!({"role": "system", "content": []}),
+            json!({"role": "system", "content": [{"type": "text", "text": ""}]}),
+            json!({"role": "user", "content": "U1"}),
+        ];
+        let out = collapse_system_messages_to_head(input);
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["role"], "user");
+    }
+
+    #[test]
+    fn collapse_system_messages_extracts_text_from_array_content() {
+        // 数组形态的非空 system 统一提取文本合并到首位；字符串是所有第三方
+        // Chat 端点都接受的形态，数组 system content 会被部分严格端点拒绝。
+        let input = vec![
+            json!({"role": "system", "content": [{"type": "text", "text": "S1"}, {"type": "text", "text": "S2"}]}),
+            json!({"role": "user", "content": "U1"}),
+        ];
+        let out = collapse_system_messages_to_head(input);
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["role"], "system");
+        assert_eq!(out[0]["content"], "S1\n\nS2");
+        assert_eq!(out[1]["content"], "U1");
+    }
+
+    #[test]
+    fn responses_to_chat_drops_empty_developer_message_for_strict_upstreams() {
+        // 端到端：静态 agent 类型（无 role prompt）可能产生空的 developer/system
+        // input item；转换后的 Chat 请求不得携带空 system 消息，否则 Kimi 400。
+        let body = json!({
+            "model": "k3-256k",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": ""}]
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "PING_123"}]
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions_with_reasoning_text_only_and_cache(
+            body, None, None, None,
+        )
+        .expect("chat conversion");
+        let messages = result["messages"].as_array().expect("messages array");
+
+        assert!(
+            messages.iter().all(|message| {
+                message.get("role").and_then(Value::as_str) != Some("system")
+                    || message["content"]
+                        .as_str()
+                        .is_some_and(|text| !text.trim().is_empty())
+            }),
+            "no empty system message may leak to strict upstreams: {messages:?}"
+        );
+        assert_eq!(messages[0]["role"], "user");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -3966,10 +3966,7 @@ mod tests {
             .find(|item| item["type"] == "message")
             .expect("message output item");
 
-        assert_eq!(
-            message["id"],
-            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9"
-        );
+        assert_eq!(message["id"], "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9");
     }
 
     #[test]

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -689,6 +689,61 @@ mod tests {
             .expect("add router to failover queue");
     }
 
+    /// 把 Codex MultiRouter 配置成 Chat 上游，base_url 指向本地 mock。
+    async fn save_codex_chat_mock_router(db: &Database, chat_base_url: &str) {
+        let mut chat_provider = Provider::with_id(
+            "k3-chat".to_string(),
+            "Kimi K3".to_string(),
+            json!({
+                "base_url": chat_base_url,
+                "api_key": "sk-k3"
+            }),
+            None,
+        );
+        chat_provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_chat".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &chat_provider)
+            .expect("save chat provider");
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "router".to_string(),
+                "Codex Router".to_string(),
+                json!({
+                    "codexRouting": {
+                        "enabled": true,
+                        "defaultRouteId": "k3",
+                        "routes": [
+                            {
+                                "id": "k3",
+                                "label": "Kimi K3",
+                                "enabled": true,
+                                "targetProviderId": "k3-chat",
+                                "match": { "models": ["k3"] },
+                                "upstream": { "apiFormat": "openai_chat" }
+                            }
+                        ]
+                    }
+                }),
+                None,
+            ),
+        )
+        .expect("save router provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("read codex proxy config");
+        proxy_config.enabled = true;
+        proxy_config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex proxy config");
+        db.add_to_failover_queue("codex", "router")
+            .expect("add router to failover queue");
+    }
+
     #[test]
     fn bind_error_for_addr_in_use_includes_actionable_port_diagnostic() {
         let addr: SocketAddr = "127.0.0.1:15721".parse().expect("socket addr");
@@ -2393,6 +2448,258 @@ base_url = "http://127.0.0.1:15721/v1"
 
     #[tokio::test]
     #[serial]
+    async fn codex_v1_responses_chat_mock_hosted_web_search_replays_full_lifecycle() {
+        let chat_captured = Arc::new(Mutex::new(None));
+        let (chat_base_url, _chat_task) =
+            spawn_openai_chat_mock_with_capture(chat_captured.clone()).await;
+        let (server, db) = build_test_server();
+        save_codex_chat_mock_router(&db, &chat_base_url).await;
+
+        let request_body = json!({
+            "model": "k3",
+            "stream": true,
+            "tools": [{
+                "type": "web_search",
+                "external_web_access": true,
+                "search_content_types": ["text", "image"]
+            }],
+            "tool_choice": { "type": "web_search" },
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "search" }]
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let response_text = String::from_utf8_lossy(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("collect hosted tool response")
+                .to_bytes(),
+        )
+        .to_string();
+        let created_pos = response_text
+            .find("event: response.created")
+            .expect("response.created event");
+        let delta_pos = response_text
+            .find("event: response.output_text.delta")
+            .expect("output_text.delta event");
+        let completed_pos = response_text
+            .find("event: response.completed")
+            .expect("response.completed event");
+        assert!(
+            created_pos < delta_pos && delta_pos < completed_pos,
+            "hosted web_search must replay the full lifecycle: {response_text}"
+        );
+        assert!(
+            response_text.contains("\"id\":\"msg_resp_chatcmpl_mock\""),
+            "chat-sourced message id should use msg_ prefix: {response_text}"
+        );
+
+        let chat_body = chat_captured
+            .lock()
+            .expect("captured chat request lock")
+            .clone()
+            .expect("captured chat request");
+        assert_eq!(chat_body["stream"], false);
+        assert_eq!(chat_body["tools"][0]["function"]["name"], "web_search");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_anthropic_mock_round_trip_uses_msg_prefix() {
+        let anthropic_captured = Arc::new(Mutex::new(None));
+        let (anthropic_base_url, _anthropic_task) =
+            spawn_anthropic_messages_mock(anthropic_captured.clone()).await;
+        let (server, db) = build_test_server();
+
+        let mut anthropic_provider = Provider::with_id(
+            "claude-anthropic".to_string(),
+            "Claude Anthropic".to_string(),
+            json!({
+                "base_url": anthropic_base_url,
+                "api_key": "sk-anthropic"
+            }),
+            None,
+        );
+        anthropic_provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("anthropic_messages".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &anthropic_provider)
+            .expect("save anthropic provider");
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "router".to_string(),
+                "Codex Router".to_string(),
+                json!({
+                    "codexRouting": {
+                        "enabled": true,
+                        "defaultRouteId": "claude",
+                        "routes": [
+                            {
+                                "id": "claude",
+                                "label": "Claude Anthropic",
+                                "enabled": true,
+                                "targetProviderId": "claude-anthropic",
+                                "match": { "models": ["claude"] },
+                                "upstream": { "apiFormat": "anthropic_messages" }
+                            }
+                        ]
+                    }
+                }),
+                None,
+            ),
+        )
+        .expect("save router provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("read codex proxy config");
+        proxy_config.enabled = true;
+        proxy_config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex proxy config");
+        db.add_to_failover_queue("codex", "router")
+            .expect("add router to failover queue");
+
+        let request_body = json!({
+            "model": "claude",
+            "stream": true,
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "ping" }]
+                }
+            ]
+        });
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let response_text = String::from_utf8_lossy(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("collect anthropic response")
+                .to_bytes(),
+        )
+        .to_string();
+        assert!(
+            response_text.contains("\"id\":\"msg_resp_msg_1_0\""),
+            "Anthropic-derived message id should use msg_ prefix: {response_text}"
+        );
+        assert!(response_text.contains("event: response.completed"));
+
+        let anthropic_body = anthropic_captured
+            .lock()
+            .expect("captured anthropic request lock")
+            .clone()
+            .expect("captured anthropic request");
+        assert!(
+            anthropic_body["body"]["messages"].is_array(),
+            "Anthropic mock should receive messages array: {anthropic_body}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_lite_official_mock_strips_replayed_item_ids() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock(captured_request.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "old turn" }]
+                }
+            ]
+        });
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(
+                        http::header::HeaderName::from_static(
+                            "x-openai-internal-codex-responses-lite",
+                        ),
+                        "1",
+                    )
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        assert!(
+            input[0].get("id").is_none(),
+            "responses-lite official mock must not receive replayed ids"
+        );
+        assert_eq!(input[0]["content"][0]["text"], "old turn");
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn codex_v1_responses_third_party_mock_preserves_native_agent_message_ids() {
         let captured_request = Arc::new(Mutex::new(None));
         let (upstream_base_url, _upstream_task) =
@@ -2627,6 +2934,52 @@ base_url = "http://127.0.0.1:15721/v1"
             axum::serve(listener, app)
                 .await
                 .expect("502 mock upstream serve");
+        });
+        (format!("http://{addr}"), task)
+    }
+
+    /// 启动 Anthropic Messages mock，捕获出站请求并返回一条文本消息。
+    async fn spawn_anthropic_messages_mock(
+        captured_request: Arc<Mutex<Option<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().route(
+            "/v1/messages",
+            post(move |headers: HeaderMap, body: Bytes| {
+                let captured_request = captured_request.clone();
+                async move {
+                    let parsed_body =
+                        serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!(null));
+                    *captured_request.lock().expect("capture anthropic request") = Some(json!({
+                        "authorization": headers
+                            .get(header::AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or("")
+                            .to_string(),
+                        "body": parsed_body
+                    }));
+                    Json(json!({
+                        "id": "msg_1",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude",
+                        "content": [{ "type": "text", "text": "pong" }],
+                        "stop_reason": "end_turn",
+                        "usage": {
+                            "input_tokens": 1,
+                            "output_tokens": 1
+                        }
+                    }))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind anthropic mock upstream");
+        let addr = listener.local_addr().expect("anthropic mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("anthropic mock upstream serve");
         });
         (format!("http://{addr}"), task)
     }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -744,6 +744,61 @@ mod tests {
             .expect("add router to failover queue");
     }
 
+    /// 把 Codex MultiRouter 配置成第三方 Responses 直透上游，base_url 指向本地 mock。
+    async fn save_codex_responses_mock_router(db: &Database, responses_base_url: &str) {
+        let mut responses_provider = Provider::with_id(
+            "deepseek-responses".to_string(),
+            "DeepSeek-responses".to_string(),
+            json!({
+                "base_url": responses_base_url,
+                "api_key": "sk-deepseek"
+            }),
+            None,
+        );
+        responses_provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &responses_provider)
+            .expect("save responses provider");
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "router".to_string(),
+                "Codex Router".to_string(),
+                json!({
+                    "codexRouting": {
+                        "enabled": true,
+                        "defaultRouteId": "deepseek",
+                        "routes": [
+                            {
+                                "id": "deepseek",
+                                "label": "DeepSeek-responses",
+                                "enabled": true,
+                                "targetProviderId": "deepseek-responses",
+                                "match": { "models": ["deepseek-v4-flash"] },
+                                "upstream": { "apiFormat": "openai_responses" }
+                            }
+                        ]
+                    }
+                }),
+                None,
+            ),
+        )
+        .expect("save router provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("read codex proxy config");
+        proxy_config.enabled = true;
+        proxy_config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex proxy config");
+        db.add_to_failover_queue("codex", "router")
+            .expect("add router to failover queue");
+    }
+
     #[test]
     fn bind_error_for_addr_in_use_includes_actionable_port_diagnostic() {
         let addr: SocketAddr = "127.0.0.1:15721".parse().expect("socket addr");
@@ -2613,6 +2668,311 @@ base_url = "http://127.0.0.1:15721/v1"
 
     #[tokio::test]
     #[serial]
+    async fn codex_v1_compaction_chat_mock_overflow_escalates_trim_rounds() {
+        // 第一轮 1/2 裁剪后仍溢出时，必须继续第二轮 1/4 裁剪并在成功时返回 200；
+        // 出站 messages 数量逐轮递减。
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+        let (chat_base_url, _chat_task) = spawn_chat_staged_mock(
+            captured_requests.clone(),
+            vec![
+                StatusCode::UNAUTHORIZED,
+                StatusCode::UNAUTHORIZED,
+                StatusCode::OK,
+            ],
+        )
+        .await;
+        let (server, db) = build_test_server();
+        save_codex_chat_mock_router(&db, &chat_base_url).await;
+
+        let response = server
+            .build_router()
+            .oneshot(v2_compaction_mock_request(&v2_compaction_mock_body()))
+            .await
+            .expect("escalated compaction response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "second trim round must succeed instead of surfacing the overflow 401"
+        );
+
+        let requests = captured_requests
+            .lock()
+            .expect("captured requests lock")
+            .clone();
+        assert_eq!(requests.len(), 3);
+        let message_counts: Vec<usize> = requests
+            .iter()
+            .map(|request| {
+                request["body"]["messages"]
+                    .as_array()
+                    .expect("upstream messages")
+                    .len()
+            })
+            .collect();
+        assert!(
+            message_counts[1] < message_counts[0],
+            "first trim must halve history: {message_counts:?}"
+        );
+        assert!(
+            message_counts[2] < message_counts[1],
+            "second trim must shrink further: {message_counts:?}"
+        );
+        assert!(requests[2]["body"].to_string().contains("compact now"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_compaction_chat_mock_overflow_exhausted_trim_surfaces_error() {
+        // 两轮裁剪都仍溢出时，不能吞掉错误或无限重试：客户端必须拿到上游 401，
+        // 且总出站次数为原始请求 + 两轮裁剪。
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+        let (chat_base_url, _chat_task) = spawn_chat_staged_mock(
+            captured_requests.clone(),
+            vec![
+                StatusCode::UNAUTHORIZED,
+                StatusCode::UNAUTHORIZED,
+                StatusCode::UNAUTHORIZED,
+            ],
+        )
+        .await;
+        let (server, db) = build_test_server();
+        save_codex_chat_mock_router(&db, &chat_base_url).await;
+
+        let response = server
+            .build_router()
+            .oneshot(v2_compaction_mock_request(&v2_compaction_mock_body()))
+            .await
+            .expect("exhausted compaction response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "overflow must surface as the upstream 401 after both trim rounds fail"
+        );
+        let requests = captured_requests
+            .lock()
+            .expect("captured requests lock")
+            .clone();
+        assert_eq!(requests.len(), 3);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_turn_chat_mock_overflow_never_trims_history() {
+        // turn 请求收到 Kimi 溢出 401 时绝不能走裁剪重试：只出站一次，直接透传错误，
+        // 否则会篡改用户正在进行的对话历史。
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+        let (chat_base_url, _chat_task) =
+            spawn_chat_staged_mock(captured_requests.clone(), vec![StatusCode::UNAUTHORIZED]).await;
+        let (server, db) = build_test_server();
+        save_codex_chat_mock_router(&db, &chat_base_url).await;
+
+        let response = server
+            .build_router()
+            .oneshot(plain_responses_mock_request(
+                "k3",
+                json!([{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "continue" }]
+                }]),
+            ))
+            .await
+            .expect("turn response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let requests = captured_requests
+            .lock()
+            .expect("captured requests lock")
+            .clone();
+        assert_eq!(
+            requests.len(),
+            1,
+            "turn overflow must not trigger history trimming"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_turn_chat_mock_empty_choices_maps_to_retryable_502() {
+        // Kimi 偶发 HTTP 200 + 空 choices：必须按 502 可重试错误返回给 Codex
+        // 客户端，而不是 422 卡死整轮对话。
+        let captured_body = Arc::new(Mutex::new(None));
+        let (chat_base_url, _chat_task) =
+            spawn_chat_empty_choices_mock(captured_body.clone()).await;
+        let (server, db) = build_test_server();
+        save_codex_chat_mock_router(&db, &chat_base_url).await;
+
+        let response = server
+            .build_router()
+            .oneshot(plain_responses_mock_request(
+                "k3",
+                json!([{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "ping" }]
+                }]),
+            ))
+            .await
+            .expect("empty choices response");
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = response_json(response).await;
+        // transform 阶段的 UpstreamError 由 axum IntoResponse 包装，只有
+        // message/type；Codex 客户端的 502 重连只看 HTTP 状态码。
+        assert_eq!(body["error"]["type"], "upstream_error");
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("HTTP 200 with empty choices"));
+        assert!(captured_body
+            .lock()
+            .expect("captured upstream body lock")
+            .is_some());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_chat_mock_drops_empty_system_before_upstream() {
+        // 静态 agent 类型可能产生空 developer/system input item；出站 Chat 请求
+        // 不得携带空 system 消息，否则 Kimi 整请求 400。
+        let captured_body = Arc::new(Mutex::new(None));
+        let (chat_base_url, _chat_task) =
+            spawn_openai_chat_mock_with_capture(captured_body.clone()).await;
+        let (server, db) = build_test_server();
+        save_codex_chat_mock_router(&db, &chat_base_url).await;
+
+        let response = server
+            .build_router()
+            .oneshot(plain_responses_mock_request(
+                "k3",
+                json!([
+                    {
+                        "type": "message",
+                        "role": "developer",
+                        "content": [{ "type": "input_text", "text": "" }]
+                    },
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{ "type": "input_text", "text": "PING_123" }]
+                    }
+                ]),
+            ))
+            .await
+            .expect("empty system response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let chat_body = captured_body
+            .lock()
+            .expect("captured upstream body lock")
+            .clone()
+            .expect("captured chat body");
+        let messages = chat_body["messages"].as_array().expect("messages array");
+        assert!(
+            messages
+                .iter()
+                .all(|message| message.get("role").and_then(Value::as_str) != Some("system")),
+            "no system message may reach strict upstreams when empty: {messages:?}"
+        );
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"], "PING_123");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_mock_recovers_official_reasoning_for_third_party() {
+        // 官方路由回放的 reasoning item（encrypted_content + summary）在切到
+        // 第三方 Responses 直透时必须转成 reasoning_text content 并移除私有密文，
+        // 否则 DeepSeek thinking 模式整请求 400。
+        let captured_body = Arc::new(Mutex::new(None));
+        let (responses_base_url, _responses_task) =
+            spawn_openai_responses_mock_with_capture(captured_body.clone()).await;
+        let (server, db) = build_test_server();
+        save_codex_responses_mock_router(&db, &responses_base_url).await;
+
+        let response = server
+            .build_router()
+            .oneshot(plain_responses_mock_request(
+                "deepseek-v4-flash",
+                json!([
+                    {
+                        "type": "reasoning",
+                        "id": "rs_official",
+                        "summary": [{ "type": "summary_text", "text": "Need to inspect the code." }],
+                        "encrypted_content": "gAAAAAB..."
+                    },
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{ "type": "input_text", "text": "continue" }]
+                    }
+                ]),
+            ))
+            .await
+            .expect("responses passthrough response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let upstream_body = captured_body
+            .lock()
+            .expect("captured upstream body lock")
+            .clone()
+            .expect("captured responses body");
+        let reasoning = &upstream_body["input"][0];
+        assert_eq!(reasoning["type"], "reasoning");
+        assert!(reasoning.get("encrypted_content").is_none());
+        assert_eq!(reasoning["content"][0]["type"], "reasoning_text");
+        assert_eq!(reasoning["content"][0]["text"], "Need to inspect the code.");
+    }
+
+    fn v2_compaction_mock_body() -> Value {
+        json!({
+            "model": "k3",
+            "input": [
+                { "type": "compaction_trigger" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "old question" }] },
+                { "type": "function_call", "call_id": "call_1", "name": "read", "arguments": "{}" },
+                { "type": "function_call_output", "call_id": "call_1", "output": "old result" },
+                { "type": "message", "role": "assistant", "content": [{ "type": "output_text", "text": "mid answer" }] },
+                { "type": "reasoning", "summary": [{ "type": "summary_text", "text": "thinking" }] },
+                { "type": "function_call", "call_id": "call_2", "name": "write", "arguments": "{}" },
+                { "type": "function_call_output", "call_id": "call_2", "output": "new result" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "compact now" }] }
+            ]
+        })
+    }
+
+    fn v2_compaction_mock_request(body: &Value) -> Request<Body> {
+        Request::builder()
+            .method(Method::POST)
+            .uri("/v1/responses")
+            .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+            .header(header::USER_AGENT, "codex/0.146.0-test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(
+                "x-codex-turn-metadata",
+                r#"{"request_kind":"compaction","compaction":{"trigger":"auto","implementation":"responses_compaction_v2","phase":"pre_turn"}}"#,
+            )
+            .body(Body::from(body.to_string()))
+            .expect("compaction request")
+    }
+
+    fn plain_responses_mock_request(model: &str, input: Value) -> Request<Body> {
+        Request::builder()
+            .method(Method::POST)
+            .uri("/v1/responses")
+            .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+            .header(header::USER_AGENT, "codex/0.146.0-test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({ "model": model, "input": input }).to_string(),
+            ))
+            .expect("plain request")
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn codex_v1_responses_anthropic_mock_round_trip_uses_msg_prefix() {
         let anthropic_captured = Arc::new(Mutex::new(None));
         let (anthropic_base_url, _anthropic_task) =
@@ -3168,6 +3528,46 @@ base_url = "http://127.0.0.1:15721/v1"
         (format!("http://{addr}/v1"), task)
     }
 
+    /// 启动第三方 OpenAI Responses 直透 mock，捕获出站请求体并返回一个
+    /// 简单 completed Responses 响应。用于仿真第三方 Responses 路由的规整行为。
+    async fn spawn_openai_responses_mock_with_capture(
+        captured_body: Arc<Mutex<Option<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().route(
+            "/v1/responses",
+            post(move |Json(body): Json<Value>| {
+                let captured_body = captured_body.clone();
+                async move {
+                    *captured_body.lock().expect("capture upstream body") = Some(body);
+                    Json(json!({
+                        "id": "resp_mock",
+                        "object": "response",
+                        "created_at": 0,
+                        "status": "completed",
+                        "model": "deepseek-v4-flash",
+                        "output": [],
+                        "usage": {
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "total_tokens": 0
+                        }
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind responses mock upstream");
+        let addr = listener.local_addr().expect("responses mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("responses mock upstream serve");
+        });
+        (format!("http://{addr}/v1"), task)
+    }
+
     /// 启动 Chat 上游 mock：第一次回 401 Kimi 上下文溢出，之后回正常 chat completion，
     /// 并捕获每次出站请求体供断言裁剪行为。
     async fn spawn_chat_overflow_then_success_mock(
@@ -3224,6 +3624,116 @@ base_url = "http://127.0.0.1:15721/v1"
             axum::serve(listener, app)
                 .await
                 .expect("overflow mock upstream serve");
+        });
+        (format!("http://{addr}/v1"), task)
+    }
+
+    /// 启动按状态序列响应的 Chat 上游 mock：按索引消费 `statuses` 返回对应
+    /// 状态（非 OK 回 Kimi 溢出体，OK 回正常 chat completion），并捕获每次
+    /// 出站请求体。用于仿真溢出裁剪的阶梯与最终失败路径。
+    async fn spawn_chat_staged_mock(
+        captured_requests: Arc<Mutex<Vec<Value>>>,
+        statuses: Vec<StatusCode>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let statuses = Arc::new(statuses);
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move |Json(body): Json<Value>| {
+                let captured_requests = captured_requests.clone();
+                let attempts = attempts.clone();
+                let statuses = statuses.clone();
+                async move {
+                    captured_requests
+                        .lock()
+                        .expect("capture requests lock")
+                        .push(json!({ "body": body }));
+                    let index = attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let status = statuses
+                        .get(index)
+                        .copied()
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    if status != StatusCode::OK {
+                        return (
+                            status,
+                            Json(json!({
+                                "error": {
+                                    "message": "k3-256k supports only 256K context.",
+                                    "type": "authentication_error"
+                                }
+                            })),
+                        )
+                            .into_response();
+                    }
+                    Json(json!({
+                        "id": "chatcmpl_compact",
+                        "object": "chat.completion",
+                        "created": 0,
+                        "model": "k3",
+                        "choices": [{
+                            "index": 0,
+                            "message": { "role": "assistant", "content": "compact summary" },
+                            "finish_reason": "stop"
+                        }],
+                        "usage": {
+                            "prompt_tokens": 1,
+                            "completion_tokens": 1,
+                            "total_tokens": 2
+                        }
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind staged mock upstream");
+        let addr = listener.local_addr().expect("staged mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("staged mock upstream serve");
+        });
+        (format!("http://{addr}/v1"), task)
+    }
+
+    /// 启动返回 HTTP 200 + 空 choices 的 Chat 上游 mock，并捕获出站请求体。
+    /// 用于仿真 Kimi 瞬态空 choices 场景。
+    async fn spawn_chat_empty_choices_mock(
+        captured_body: Arc<Mutex<Option<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move |Json(body): Json<Value>| {
+                let captured_body = captured_body.clone();
+                async move {
+                    *captured_body.lock().expect("capture upstream body") = Some(body);
+                    Json(json!({
+                        "id": "chatcmpl_empty",
+                        "object": "chat.completion",
+                        "created": 0,
+                        "model": "k3",
+                        "choices": [],
+                        "usage": {
+                            "prompt_tokens": 1,
+                            "completion_tokens": 1,
+                            "total_tokens": 2
+                        }
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind empty choices mock upstream");
+        let addr = listener
+            .local_addr()
+            .expect("empty choices mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("empty choices mock upstream serve");
         });
         (format!("http://{addr}/v1"), task)
     }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -2527,6 +2527,92 @@ base_url = "http://127.0.0.1:15721/v1"
 
     #[tokio::test]
     #[serial]
+    async fn codex_v1_compaction_chat_mock_overflow_trims_history_and_retries() {
+        // 端到端验证 Kimi 256K 溢出修复：v2 compaction 首次 401
+        // "supports only 256K context" 后，代理必须用裁剪后的历史对同一供应商
+        // 重试，而不是直接把 401 抛回客户端。第二次出站请求的 messages 必须
+        // 少于第一次，且保留压缩指令。
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+        let (chat_base_url, _chat_task) =
+            spawn_chat_overflow_then_success_mock(captured_requests.clone()).await;
+        let (server, db) = build_test_server();
+        save_codex_chat_mock_router(&db, &chat_base_url).await;
+
+        let request_body = json!({
+            "model": "k3",
+            "input": [
+                { "type": "compaction_trigger" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "old question" }] },
+                { "type": "function_call", "call_id": "call_1", "name": "read", "arguments": "{}" },
+                { "type": "function_call_output", "call_id": "call_1", "output": "old result" },
+                { "type": "message", "role": "assistant", "content": [{ "type": "output_text", "text": "mid answer" }] },
+                { "type": "reasoning", "summary": [{ "type": "summary_text", "text": "thinking" }] },
+                { "type": "function_call", "call_id": "call_2", "name": "write", "arguments": "{}" },
+                { "type": "function_call_output", "call_id": "call_2", "output": "new result" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "compact now" }] }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(
+                        "x-codex-turn-metadata",
+                        r#"{"request_kind":"compaction","compaction":{"trigger":"auto","implementation":"responses_compaction_v2","phase":"pre_turn"}}"#,
+                    )
+                    .body(Body::from(request_body.to_string()))
+                    .expect("compaction request"),
+            )
+            .await
+            .expect("compaction response");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "overflowed v2 compaction must be retried with trimmed history, not surfaced as 401"
+        );
+
+        let requests = captured_requests
+            .lock()
+            .expect("captured requests lock")
+            .clone();
+        assert_eq!(
+            requests.len(),
+            2,
+            "expected original attempt + trimmed retry"
+        );
+        let first_messages = requests[0]["body"]["messages"]
+            .as_array()
+            .expect("first upstream messages");
+        let retry_messages = requests[1]["body"]["messages"]
+            .as_array()
+            .expect("retry upstream messages");
+        assert!(
+            retry_messages.len() < first_messages.len(),
+            "trimmed retry must carry fewer messages: first={} retry={}",
+            first_messages.len(),
+            retry_messages.len()
+        );
+
+        let retry_text = requests[1]["body"].to_string();
+        assert!(
+            retry_text.contains("compact now"),
+            "compaction instruction must survive trimming: {retry_text}"
+        );
+        assert!(
+            !retry_text.contains("old question"),
+            "oldest history must be trimmed from the retry: {retry_text}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn codex_v1_responses_anthropic_mock_round_trip_uses_msg_prefix() {
         let anthropic_captured = Arc::new(Mutex::new(None));
         let (anthropic_base_url, _anthropic_task) =
@@ -3078,6 +3164,66 @@ base_url = "http://127.0.0.1:15721/v1"
             axum::serve(listener, app)
                 .await
                 .expect("mock upstream serve");
+        });
+        (format!("http://{addr}/v1"), task)
+    }
+
+    /// 启动 Chat 上游 mock：第一次回 401 Kimi 上下文溢出，之后回正常 chat completion，
+    /// 并捕获每次出站请求体供断言裁剪行为。
+    async fn spawn_chat_overflow_then_success_mock(
+        captured_requests: Arc<Mutex<Vec<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move |Json(body): Json<Value>| {
+                let captured_requests = captured_requests.clone();
+                let attempts = attempts.clone();
+                async move {
+                    captured_requests
+                        .lock()
+                        .expect("capture requests lock")
+                        .push(json!({ "body": body }));
+                    if attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                        return (
+                            StatusCode::UNAUTHORIZED,
+                            Json(json!({
+                                "error": {
+                                    "message": "k3-256k supports only 256K context.",
+                                    "type": "authentication_error"
+                                }
+                            })),
+                        )
+                            .into_response();
+                    }
+                    Json(json!({
+                        "id": "chatcmpl_compact",
+                        "object": "chat.completion",
+                        "created": 0,
+                        "model": "k3",
+                        "choices": [{
+                            "index": 0,
+                            "message": { "role": "assistant", "content": "compact summary" },
+                            "finish_reason": "stop"
+                        }],
+                        "usage": {
+                            "prompt_tokens": 1,
+                            "completion_tokens": 1,
+                            "total_tokens": 2
+                        }
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind overflow mock upstream");
+        let addr = listener.local_addr().expect("overflow mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("overflow mock upstream serve");
         });
         (format!("http://{addr}/v1"), task)
     }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -1473,9 +1473,209 @@ base_url = "http://127.0.0.1:15721/v1"
         assert_eq!(body["output"][0]["content"][0]["text"], "pong");
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_official_mock_strips_replayed_item_ids() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock(captured_request.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        let mut official_provider = Provider::with_id(
+            "codex-official".to_string(),
+            "OpenAI Official".to_string(),
+            json!({
+                "base_url": format!("{upstream_base_url}/backend-api/codex"),
+                "api_key": "sk-official"
+            }),
+            None,
+        );
+        official_provider.meta = Some(crate::provider::ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &official_provider)
+            .expect("save official provider");
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "router".to_string(),
+                "Codex Router".to_string(),
+                json!({
+                    "codexRouting": {
+                        "enabled": true,
+                        "defaultRouteId": "official",
+                        "routes": [
+                            {
+                                "id": "official",
+                                "label": "OpenAI Official",
+                                "enabled": true,
+                                "targetProviderId": "codex-official",
+                                "match": { "models": ["gpt-5.6-luna"] },
+                                "upstream": { "apiFormat": "openai_responses" }
+                            }
+                        ]
+                    }
+                }),
+                None,
+            ),
+        )
+        .expect("save router provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("read codex proxy config");
+        proxy_config.enabled = true;
+        proxy_config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex proxy config");
+        db.add_to_failover_queue("codex", "router")
+            .expect("add router to failover queue");
+
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                { "type": "compaction_trigger" },
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "old turn" }]
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_resp_chatcmpl-L2v9jyTIwSBd0avrEPO8umbl",
+                    "summary": [{ "type": "summary_text", "text": "thinking" }]
+                },
+                {
+                    "type": "agent_message",
+                    "id": "msg_amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "done"
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        let status = response.status();
+        let response_body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect proxy response")
+            .to_bytes();
+        let captured_pre = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "proxy returned {status}: {}; captured={}",
+            String::from_utf8_lossy(&response_body),
+            captured_pre
+                .as_ref()
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string())
+        );
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        assert_eq!(captured["path"], "/backend-api/codex/responses");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        for item in input {
+            assert!(
+                item.get("id").is_none(),
+                "official mock must not receive replayed ids: {item}"
+            );
+        }
+        assert_eq!(input[1]["content"][0]["text"], "old turn");
+        assert_eq!(input[2]["summary"][0]["text"], "thinking");
+        assert_eq!(input[3]["content"][0]["text"], "subagent done");
+        assert_eq!(input[4]["call_id"], "call_1");
+    }
+
     /// 启动一个只服务 OpenAI Chat Completions 的本地 mock upstream。
     async fn spawn_openai_chat_mock() -> (String, tokio::task::JoinHandle<()>) {
         spawn_openai_chat_mock_with_capture(Arc::new(Mutex::new(None))).await
+    }
+
+    /// 启动 Codex /responses 官方链路 mock，捕获真实出站 JSON。
+    async fn spawn_codex_responses_mock(
+        captured_request: Arc<Mutex<Option<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().route(
+            "/backend-api/codex/responses",
+            post(
+                move |uri: axum::http::Uri, headers: HeaderMap, body: Bytes| {
+                    let captured_request = captured_request.clone();
+                    async move {
+                        let parsed_body =
+                            serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!(null));
+                        *captured_request.lock().expect("capture responses request") =
+                            Some(json!({
+                                "path": uri.path(),
+                                "authorization": headers
+                                    .get(header::AUTHORIZATION)
+                                    .and_then(|value| value.to_str().ok())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                "body": parsed_body
+                            }));
+                        Json(json!({
+                            "id": "resp_mock",
+                            "object": "response",
+                            "created_at": 0,
+                            "status": "completed",
+                            "model": "gpt-5.6-luna",
+                            "output": [],
+                            "usage": {
+                                "input_tokens": 0,
+                                "output_tokens": 0,
+                                "total_tokens": 0
+                            }
+                        }))
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind responses mock upstream");
+        let addr = listener.local_addr().expect("responses mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("responses mock upstream serve");
+        });
+        (format!("http://{addr}"), task)
     }
 
     /// 启动一个会保存最近一次请求体的 OpenAI Chat mock，用于断言代理转发前后文本不变。

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -634,6 +634,61 @@ mod tests {
         )
     }
 
+    /// 把 Codex MultiRouter 配置成官方 OAuth 路由，但 base_url 指向本地 mock。
+    async fn save_codex_official_mock_router(db: &Database, official_base_url: &str) {
+        let mut official_provider = Provider::with_id(
+            "codex-official".to_string(),
+            "OpenAI Official".to_string(),
+            json!({
+                "base_url": format!("{official_base_url}/backend-api/codex"),
+                "api_key": "sk-official"
+            }),
+            None,
+        );
+        official_provider.meta = Some(crate::provider::ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &official_provider)
+            .expect("save official provider");
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "router".to_string(),
+                "Codex Router".to_string(),
+                json!({
+                    "codexRouting": {
+                        "enabled": true,
+                        "defaultRouteId": "official",
+                        "routes": [
+                            {
+                                "id": "official",
+                                "label": "OpenAI Official",
+                                "enabled": true,
+                                "targetProviderId": "codex-official",
+                                "match": { "models": ["gpt-5.6-luna"] },
+                                "upstream": { "apiFormat": "openai_responses" }
+                            }
+                        ]
+                    }
+                }),
+                None,
+            ),
+        )
+        .expect("save router provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("read codex proxy config");
+        proxy_config.enabled = true;
+        proxy_config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex proxy config");
+        db.add_to_failover_queue("codex", "router")
+            .expect("add router to failover queue");
+    }
+
     #[test]
     fn bind_error_for_addr_in_use_includes_actionable_port_diagnostic() {
         let addr: SocketAddr = "127.0.0.1:15721".parse().expect("socket addr");
@@ -1483,57 +1538,7 @@ base_url = "http://127.0.0.1:15721/v1"
         std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
 
         let (server, db) = build_test_server();
-        let mut official_provider = Provider::with_id(
-            "codex-official".to_string(),
-            "OpenAI Official".to_string(),
-            json!({
-                "base_url": format!("{upstream_base_url}/backend-api/codex"),
-                "api_key": "sk-official"
-            }),
-            None,
-        );
-        official_provider.meta = Some(crate::provider::ProviderMeta {
-            provider_type: Some("codex_oauth".to_string()),
-            ..Default::default()
-        });
-        db.save_provider("codex", &official_provider)
-            .expect("save official provider");
-        db.save_provider(
-            "codex",
-            &Provider::with_id(
-                "router".to_string(),
-                "Codex Router".to_string(),
-                json!({
-                    "codexRouting": {
-                        "enabled": true,
-                        "defaultRouteId": "official",
-                        "routes": [
-                            {
-                                "id": "official",
-                                "label": "OpenAI Official",
-                                "enabled": true,
-                                "targetProviderId": "codex-official",
-                                "match": { "models": ["gpt-5.6-luna"] },
-                                "upstream": { "apiFormat": "openai_responses" }
-                            }
-                        ]
-                    }
-                }),
-                None,
-            ),
-        )
-        .expect("save router provider");
-        let mut proxy_config = db
-            .get_proxy_config_for_app("codex")
-            .await
-            .expect("read codex proxy config");
-        proxy_config.enabled = true;
-        proxy_config.auto_failover_enabled = true;
-        db.update_proxy_config_for_app(proxy_config)
-            .await
-            .expect("enable codex proxy config");
-        db.add_to_failover_queue("codex", "router")
-            .expect("add router to failover queue");
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
 
         let request_body = json!({
             "model": "gpt-5.6-luna",
@@ -1622,6 +1627,883 @@ base_url = "http://127.0.0.1:15721/v1"
         assert_eq!(input[4]["call_id"], "call_1");
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_official_mock_streaming_strips_replayed_item_ids() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_sse_mock(captured_request.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "stream": true,
+            "input": [
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "old turn" }]
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_resp_chatcmpl-L2v9jyTIwSBd0avrEPO8umbl",
+                    "summary": [{ "type": "summary_text", "text": "thinking" }]
+                },
+                {
+                    "type": "agent_message",
+                    "id": "msg_amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(response.status(), StatusCode::OK);
+        let response_text = String::from_utf8_lossy(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("collect stream")
+                .to_bytes(),
+        )
+        .to_string();
+        let created_pos = response_text
+            .find("event: response.created")
+            .expect("response.created event");
+        let delta_pos = response_text
+            .find("event: response.output_text.delta")
+            .expect("output_text.delta event");
+        let completed_pos = response_text
+            .find("event: response.completed")
+            .expect("response.completed event");
+        assert!(
+            created_pos < delta_pos && delta_pos < completed_pos,
+            "Codex needs the full Responses lifecycle, otherwise it reconnects: {response_text}"
+        );
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        for item in input {
+            assert!(
+                item.get("id").is_none(),
+                "official streaming mock must not receive replayed ids: {item}"
+            );
+        }
+        assert_eq!(input[0]["content"][0]["text"], "old turn");
+        assert_eq!(input[1]["summary"][0]["text"], "thinking");
+        assert_eq!(input[2]["content"][0]["text"], "subagent done");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_compact_official_mock_strips_replayed_item_ids() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock(captured_request.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                { "type": "compaction_trigger" },
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "old turn" }]
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_resp_chatcmpl-L2v9jyTIwSBd0avrEPO8umbl",
+                    "summary": [{ "type": "summary_text", "text": "thinking" }]
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses/compact")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        let status = response.status();
+        let response_body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect compact response")
+            .to_bytes();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "compact proxy returned {status}: {}",
+            String::from_utf8_lossy(&response_body)
+        );
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        assert_eq!(input[0]["type"], "compaction_trigger");
+        for item in input {
+            assert!(
+                item.get("id").is_none(),
+                "official compact mock must not receive replayed ids: {item}"
+            );
+        }
+        assert_eq!(input[1]["content"][0]["text"], "old turn");
+        assert_eq!(input[2]["summary"][0]["text"], "thinking");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_cross_provider_chat_then_official_mock_drops_replayed_history_ids() {
+        let chat_captured = Arc::new(Mutex::new(None));
+        let (chat_base_url, _chat_task) =
+            spawn_openai_chat_mock_with_capture(chat_captured.clone()).await;
+        let official_captured = Arc::new(Mutex::new(None));
+        let (official_base_url, _official_task) =
+            spawn_codex_responses_mock(official_captured.clone()).await;
+        let mock_official_url = format!("{official_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+
+        let mut chat_provider = Provider::with_id(
+            "k3-chat".to_string(),
+            "Kimi K3".to_string(),
+            json!({
+                "base_url": chat_base_url,
+                "api_key": "sk-k3"
+            }),
+            None,
+        );
+        chat_provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_chat".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &chat_provider)
+            .expect("save chat provider");
+
+        let mut official_provider = Provider::with_id(
+            "codex-official".to_string(),
+            "OpenAI Official".to_string(),
+            json!({
+                "base_url": format!("{official_base_url}/backend-api/codex"),
+                "api_key": "sk-official"
+            }),
+            None,
+        );
+        official_provider.meta = Some(crate::provider::ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &official_provider)
+            .expect("save official provider");
+
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "router".to_string(),
+                "Codex Router".to_string(),
+                json!({
+                    "codexRouting": {
+                        "enabled": true,
+                        "defaultRouteId": "k3",
+                        "routes": [
+                            {
+                                "id": "official",
+                                "label": "OpenAI Official",
+                                "enabled": true,
+                                "targetProviderId": "codex-official",
+                                "match": { "models": ["gpt-5.6-luna"] },
+                                "upstream": { "apiFormat": "openai_responses" }
+                            },
+                            {
+                                "id": "k3",
+                                "label": "Kimi K3",
+                                "enabled": true,
+                                "targetProviderId": "k3-chat",
+                                "match": { "models": ["k3"] },
+                                "upstream": { "apiFormat": "openai_chat" }
+                            }
+                        ]
+                    }
+                }),
+                None,
+            ),
+        )
+        .expect("save router provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("read codex proxy config");
+        proxy_config.enabled = true;
+        proxy_config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex proxy config");
+        db.add_to_failover_queue("codex", "router")
+            .expect("add router to failover queue");
+
+        let first_body = json!({
+            "model": "k3",
+            "stream": true,
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "ping" }]
+                }
+            ]
+        });
+        let first_response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(first_body.to_string()))
+                    .expect("first request"),
+            )
+            .await
+            .expect("first response");
+        assert_eq!(first_response.status(), StatusCode::OK);
+        let first_text = String::from_utf8_lossy(
+            &first_response
+                .into_body()
+                .collect()
+                .await
+                .expect("collect first response")
+                .to_bytes(),
+        )
+        .to_string();
+        assert!(
+            first_text.contains("\"id\":\"msg_resp_chatcmpl_mock\""),
+            "chat-sourced message item id should use msg_ prefix: {first_text}"
+        );
+
+        let second_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl_mock_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "pong" }]
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_resp_chatcmpl_mock",
+                    "summary": [{ "type": "summary_text", "text": "thinking" }]
+                },
+                {
+                    "type": "agent_message",
+                    "id": "msg_amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "done"
+                }
+            ]
+        });
+        let second_response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(second_body.to_string()))
+                    .expect("second request"),
+            )
+            .await
+            .expect("second response");
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(second_response.status(), StatusCode::OK);
+
+        let captured = official_captured
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured official request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        for item in input {
+            assert!(
+                item.get("id").is_none(),
+                "official mock must not receive replayed history ids: {item}"
+            );
+        }
+        assert_eq!(input[0]["content"][0]["text"], "pong");
+        assert_eq!(input[1]["summary"][0]["text"], "thinking");
+        assert_eq!(input[2]["content"][0]["text"], "subagent done");
+        assert_eq!(input[3]["call_id"], "call_1");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_official_mock_subagent_tool_history_strips_ids() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock(captured_request.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "spawn subagent" }]
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_spawn_1",
+                    "call_id": "call_spawn",
+                    "name": "spawn_agent",
+                    "arguments": r#"{"task":"check"}"#
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_spawn",
+                    "output": "ok"
+                },
+                {
+                    "type": "agent_message",
+                    "id": "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent running" }]
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_read_1",
+                    "call_id": "call_read",
+                    "name": "read_file",
+                    "arguments": r#"{"path":"README.md"}"#
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_read",
+                    "output": "content"
+                },
+                {
+                    "type": "agent_message",
+                    "id": "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        for item in input {
+            assert!(
+                item.get("id").is_none(),
+                "official mock must not receive subagent/tool ids: {item}"
+            );
+        }
+        assert_eq!(input[0]["content"][0]["text"], "spawn subagent");
+        assert_eq!(input[1]["call_id"], "call_spawn");
+        assert_eq!(input[1]["name"], "spawn_agent");
+        assert_eq!(input[1]["arguments"], r#"{"task":"check"}"#);
+        assert_eq!(input[2]["call_id"], "call_spawn");
+        assert_eq!(input[2]["output"], "ok");
+        assert_eq!(input[3]["content"][0]["text"], "subagent running");
+        assert_eq!(input[4]["call_id"], "call_read");
+        assert_eq!(input[4]["name"], "read_file");
+        assert_eq!(input[4]["arguments"], r#"{"path":"README.md"}"#);
+        assert_eq!(input[5]["call_id"], "call_read");
+        assert_eq!(input[5]["output"], "content");
+        assert_eq!(input[6]["content"][0]["text"], "subagent done");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_official_mock_recovers_plaintext_encrypted_agent_message() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock(captured_request.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "agent_message",
+                    "id": "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "encrypted_content",
+                        "encrypted_content": "subagent plaintext reply"
+                    }]
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        assert!(input[0].get("id").is_none());
+        assert_eq!(input[0]["content"][0]["type"], "input_text");
+        assert_eq!(input[0]["content"][0]["text"], "subagent plaintext reply");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_official_mock_local_tool_round_trip_preserves_call_chain() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let tool_output = json!([{
+            "type": "function_call",
+            "id": "fc_call_write",
+            "call_id": "call_write",
+            "name": "apply_patch",
+            "arguments": r#"{"patch":"local"}"#,
+            "status": "completed"
+        }]);
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock_with_output(captured_request.clone(), tool_output).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let first_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "read file" }]
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_read",
+                    "output": "file content"
+                }
+            ]
+        });
+        let first_response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(first_body.to_string()))
+                    .expect("first request"),
+            )
+            .await
+            .expect("first response");
+        assert_eq!(first_response.status(), StatusCode::OK);
+        let first_json = response_json(first_response).await;
+        assert_eq!(first_json["output"][0]["call_id"], "call_write");
+        assert_eq!(first_json["output"][0]["name"], "apply_patch");
+        assert_eq!(first_json["output"][0]["arguments"], r#"{"patch":"local"}"#);
+
+        let second_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "function_call",
+                    "id": "fc_call_write",
+                    "call_id": "call_write",
+                    "name": "apply_patch",
+                    "arguments": r#"{"patch":"local"}"#
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_write",
+                    "output": "done"
+                }
+            ]
+        });
+        let second_response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(second_body.to_string()))
+                    .expect("second request"),
+            )
+            .await
+            .expect("second response");
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(second_response.status(), StatusCode::OK);
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        for item in input {
+            assert!(
+                item.get("id").is_none(),
+                "official mock must not receive tool ids: {item}"
+            );
+        }
+        assert_eq!(input[0]["call_id"], "call_write");
+        assert_eq!(input[0]["name"], "apply_patch");
+        assert_eq!(input[0]["arguments"], r#"{"patch":"local"}"#);
+        assert_eq!(input[1]["call_id"], "call_write");
+        assert_eq!(input[1]["output"], "done");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_official_mock_preserves_real_agent_message_ciphertext() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock(captured_request.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex/responses");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let ciphertext = "AAAA".repeat(32);
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "agent_message",
+                    "id": "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "encrypted_content",
+                        "encrypted_content": ciphertext
+                    }]
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        assert!(input[0].get("id").is_none());
+        assert_eq!(input[0]["content"][0]["type"], "encrypted_content");
+        assert_eq!(input[0]["content"][0]["encrypted_content"], ciphertext);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_official_mock_502_preserves_upstream_status_and_allows_reconnect() {
+        let captured_requests = Arc::new(Mutex::new(Vec::new()));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_502_then_success_mock(captured_requests.clone()).await;
+        let mock_official_url = format!("{upstream_base_url}/backend-api/codex");
+        std::env::set_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL", &mock_official_url);
+
+        let (server, db) = build_test_server();
+        save_codex_official_mock_router(&db, &upstream_base_url).await;
+
+        let request_body = json!({
+            "model": "gpt-5.6-luna",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "ping" }]
+                }
+            ]
+        });
+
+        let first_response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("first request"),
+            )
+            .await
+            .expect("first response");
+        assert_eq!(first_response.status(), StatusCode::BAD_GATEWAY);
+        let first_json = response_json(first_response).await;
+        assert_eq!(first_json["error"]["code"], "cc_switch_upstream_error");
+        assert_eq!(first_json["error"]["upstream_status"], 502);
+        assert!(first_json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("upstream_status: HTTP 502"));
+
+        let second_response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("second request"),
+            )
+            .await
+            .expect("second response");
+        std::env::remove_var("CC_SWITCH_TEST_CODEX_OFFICIAL_MOCK_URL");
+        assert_eq!(
+            second_response.status(),
+            StatusCode::OK,
+            "Codex reconnect after official 502 must not be killed by local policy"
+        );
+
+        let requests = captured_requests
+            .lock()
+            .expect("captured requests lock")
+            .clone();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["path"], "/backend-api/codex/responses");
+        assert_eq!(requests[1]["path"], "/backend-api/codex/responses");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_v1_responses_third_party_mock_preserves_native_agent_message_ids() {
+        let captured_request = Arc::new(Mutex::new(None));
+        let (upstream_base_url, _upstream_task) =
+            spawn_codex_responses_mock(captured_request.clone()).await;
+
+        let (server, db) = build_test_server();
+        let mut responses_provider = Provider::with_id(
+            "responses-third".to_string(),
+            "Responses Third".to_string(),
+            json!({
+                "base_url": format!("{upstream_base_url}/backend-api/codex"),
+                "api_key": "sk-third"
+            }),
+            None,
+        );
+        responses_provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+        db.save_provider("codex", &responses_provider)
+            .expect("save responses provider");
+        db.save_provider(
+            "codex",
+            &Provider::with_id(
+                "router".to_string(),
+                "Codex Router".to_string(),
+                json!({
+                    "codexRouting": {
+                        "enabled": true,
+                        "defaultRouteId": "responses",
+                        "routes": [
+                            {
+                                "id": "responses",
+                                "label": "Responses Third",
+                                "enabled": true,
+                                "targetProviderId": "responses-third",
+                                "match": { "models": ["k3"] },
+                                "upstream": { "apiFormat": "openai_responses" }
+                            }
+                        ]
+                    }
+                }),
+                None,
+            ),
+        )
+        .expect("save router provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("read codex proxy config");
+        proxy_config.enabled = true;
+        proxy_config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex proxy config");
+        db.add_to_failover_queue("codex", "router")
+            .expect("add router to failover queue");
+
+        let request_body = json!({
+            "model": "k3",
+            "input": [
+                {
+                    "type": "agent_message",
+                    "id": "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "subagent done" }]
+                },
+                {
+                    "type": "message",
+                    "id": "resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "old turn" }]
+                }
+            ]
+        });
+
+        let response = server
+            .build_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/responses")
+                    .header(header::AUTHORIZATION, "Bearer PROXY_MANAGED")
+                    .header(header::USER_AGENT, "codex/0.146.0-test")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect third-party response");
+
+        let captured = captured_request
+            .lock()
+            .expect("captured responses request lock")
+            .clone()
+            .expect("captured responses request");
+        let input = captured["body"]["input"].as_array().expect("input array");
+        assert_eq!(input[0]["id"], "amsg_019fc3fa-9b0a-7db1-9ca8-131d56d047ac");
+        assert_eq!(
+            input[1]["id"],
+            "msg_resp_chatcmpl-2gyygAFeaDX2rFNtuG7mOhf9_msg"
+        );
+    }
+
     /// 启动一个只服务 OpenAI Chat Completions 的本地 mock upstream。
     async fn spawn_openai_chat_mock() -> (String, tokio::task::JoinHandle<()>) {
         spawn_openai_chat_mock_with_capture(Arc::new(Mutex::new(None))).await
@@ -1631,8 +2513,129 @@ base_url = "http://127.0.0.1:15721/v1"
     async fn spawn_codex_responses_mock(
         captured_request: Arc<Mutex<Option<Value>>>,
     ) -> (String, tokio::task::JoinHandle<()>) {
-        let app = Router::new().route(
-            "/backend-api/codex/responses",
+        spawn_codex_responses_mock_with_output(captured_request, json!([])).await
+    }
+
+    /// 启动 Codex /responses 官方链路 mock，允许自定义输出项。
+    async fn spawn_codex_responses_mock_with_output(
+        captured_request: Arc<Mutex<Option<Value>>>,
+        output: Value,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().fallback(post(
+            move |uri: axum::http::Uri, headers: HeaderMap, body: Bytes| {
+                let captured_request = captured_request.clone();
+                let output = output.clone();
+                async move {
+                    let parsed_body =
+                        serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!(null));
+                    *captured_request.lock().expect("capture responses request") = Some(json!({
+                        "path": uri.path(),
+                        "authorization": headers
+                            .get(header::AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or("")
+                            .to_string(),
+                        "body": parsed_body
+                    }));
+                    Json(json!({
+                        "id": "resp_mock",
+                        "object": "response",
+                        "created_at": 0,
+                        "status": "completed",
+                        "model": "gpt-5.6-luna",
+                        "output": output,
+                        "usage": {
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "total_tokens": 0
+                        }
+                    }))
+                }
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind responses mock upstream");
+        let addr = listener.local_addr().expect("responses mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("responses mock upstream serve");
+        });
+        (format!("http://{addr}"), task)
+    }
+
+    /// 启动官方链路的 502→200 mock：第一次回上游 502，之后回成功，
+    /// 用于验证 Codex 在官方网络抖动后的重连不会被本地策略永久吃掉。
+    async fn spawn_codex_responses_502_then_success_mock(
+        captured_requests: Arc<Mutex<Vec<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let app = Router::new().fallback(post(
+            move |uri: axum::http::Uri, headers: HeaderMap, body: Bytes| {
+                let captured_requests = captured_requests.clone();
+                let attempts = attempts.clone();
+                async move {
+                    let parsed_body =
+                        serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!(null));
+                    captured_requests
+                        .lock()
+                        .expect("capture requests lock")
+                        .push(json!({
+                            "path": uri.path(),
+                            "authorization": headers
+                                .get(header::AUTHORIZATION)
+                                .and_then(|value| value.to_str().ok())
+                                .unwrap_or("")
+                                .to_string(),
+                            "body": parsed_body
+                        }));
+                    if attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                        return (
+                            StatusCode::BAD_GATEWAY,
+                            Json(json!({
+                                "error": {
+                                    "message": "upstream gateway timeout",
+                                    "type": "server_error"
+                                }
+                            })),
+                        )
+                            .into_response();
+                    }
+                    Json(json!({
+                        "id": "resp_mock",
+                        "object": "response",
+                        "created_at": 0,
+                        "status": "completed",
+                        "model": "gpt-5.6-luna",
+                        "output": [],
+                        "usage": {
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "total_tokens": 0
+                        }
+                    }))
+                    .into_response()
+                }
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind 502 mock upstream");
+        let addr = listener.local_addr().expect("502 mock upstream addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("502 mock upstream serve");
+        });
+        (format!("http://{addr}"), task)
+    }
+
+    /// 启动 Codex /responses 官方链路的 streaming mock，捕获出站 JSON 并回 SSE。
+    async fn spawn_codex_responses_sse_mock(
+        captured_request: Arc<Mutex<Option<Value>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().fallback(
             post(
                 move |uri: axum::http::Uri, headers: HeaderMap, body: Bytes| {
                     let captured_request = captured_request.clone();
@@ -1649,31 +2652,29 @@ base_url = "http://127.0.0.1:15721/v1"
                                     .to_string(),
                                 "body": parsed_body
                             }));
-                        Json(json!({
-                            "id": "resp_mock",
-                            "object": "response",
-                            "created_at": 0,
-                            "status": "completed",
-                            "model": "gpt-5.6-luna",
-                            "output": [],
-                            "usage": {
-                                "input_tokens": 0,
-                                "output_tokens": 0,
-                                "total_tokens": 0
-                            }
-                        }))
+                        let sse = concat!(
+                            "event: response.created\n",
+                            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_mock\",\"object\":\"response\",\"status\":\"in_progress\",\"model\":\"gpt-5.6-luna\",\"output\":[]}}\n\n",
+                            "event: response.output_text.delta\n",
+                            "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_mock\",\"output_index\":0,\"delta\":\"pong\"}\n\n",
+                            "event: response.completed\n",
+                            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_mock\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"gpt-5.6-luna\",\"output\":[{\"type\":\"message\",\"id\":\"msg_mock\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"pong\",\"annotations\":[]}]}],\"usage\":{\"input_tokens\":0,\"output_tokens\":1,\"total_tokens\":1}}}\n\n"
+                        );
+                        ([(header::CONTENT_TYPE, "text/event-stream")], sse)
                     }
                 },
             ),
         );
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
-            .expect("bind responses mock upstream");
-        let addr = listener.local_addr().expect("responses mock upstream addr");
+            .expect("bind responses sse mock upstream");
+        let addr = listener
+            .local_addr()
+            .expect("responses sse mock upstream addr");
         let task = tokio::spawn(async move {
             axum::serve(listener, app)
                 .await
-                .expect("responses mock upstream serve");
+                .expect("responses sse mock upstream serve");
         });
         (format!("http://{addr}"), task)
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/wix/per-user-main.wxs
+++ b/src-tauri/wix/per-user-main.wxs
@@ -153,7 +153,7 @@
             </Component>
             <Component Id="Path" Guid="{{path_component_guid}}" Win64="$(var.Win64)">
                 <File Id="Path" Source="{{main_binary_path}}" KeyPath="no" Checksum="yes"/>
-                <RegistryValue Root="HKCU" Key="Software\{{manufacturer}}\{{product_name}}" Name="PathComponent" Type="integer" Value="1" KeyPath="yes" />
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="PathComponent" Type="integer" Value="1" KeyPath="yes" />
                 {{#each file_associations as |association| ~}}
                 {{#each association.ext as |ext| ~}}
                 <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="yes" Description="{{association.description}}">
@@ -167,7 +167,7 @@
             {{#each binaries as |bin| ~}}
             <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
                 <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="no"/>
-                <RegistryValue Root="HKCU" Key="Software\{{manufacturer}}\{{product_name}}" Name="Bin_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes" />
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Bin_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes" />
             </Component>
             {{/each~}}
             {{#if enable_elevated_update_task}}


### PR DESCRIPTION
Related: #28

## 本 PR 覆盖

### 原有内容（分支早期提交）
- Responses input item id 规整：message/agent_message 补 `msg_`/`amsg_` 前缀，官方 OAuth store=false 路径剥 id 防 404。
- 官方 OAuth compaction 仿真与 502 重连测试。

### 本次新增修复

1. **DeepSeek-responses `reasoning_text` 400（compaction 必现）**
   官方路由回放的 reasoning item 只有 `encrypted_content`+空 `summary`，第三方 thinking 模式要求历史 reasoning 携带 `reasoning_text`。透传层规整：已有文本原样保留；summary 提升为 `reasoning_text` 并移除私有密文；密文+空 summary 丢弃。

2. **Kimi For Coding 256K 上下文溢出 401**
   v2 compaction 把跨路由整段历史塞进单请求，切到 256K 级模型即溢出（Kimi 返回 401 `supports only 256K context`）。仅对 v2 compaction 检测溢出，同供应商两轮阶梯裁剪重试（1/2 → 1/4）；结构性 item（compaction 控制项+压缩指令）永保、孤儿 tool output 清理；turn 请求绝不裁剪。

3. **Kimi 200 + 空 choices → 422 卡死**
   映射为 502 可重试错误，走 Codex 客户端 502 重连自动恢复。

4. **空 system/developer 消息 → Kimi 400**
   responses→chat 转换丢弃 null/空串/空白/空数组 system，非空数组提取文本合并到首位。

## 验证

- `cargo test --lib`：2811 passed；3 个已知既有/环境失败（transform_codex_anthropic 两测试 origin/main 复跑同败；15721 端口被运行中 App 占用）。
- HTTP 级仿真（真实代理链路 + 本地 mock）19 场景全过：单轮/两轮裁剪、失败透传 401、turn 不裁剪、空 choices→502、空 system 不外泄、官方 reasoning→第三方 reasoning_text、官方 OAuth 502 重连等。
- clippy 警告数与基线一致（无新增）；rustfmt 通过。

## 提交

- `3ddd7cd4` recover replayed reasoning items on third-party Responses passthrough
- `d5e1418c` trim replayed history and retry v2 compaction on context overflow
- `81e5e333` drop effectively empty system messages in Codex chat conversion
- `537ccee7` retry chat upstream 200 responses with empty choices
- `ee39c40e` cover all overflow, empty-choices and reasoning recovery scenarios end to end

draft 供检查，等待 review。